### PR TITLE
Move to latest v1alpha2 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ MOCKGEN := $(TOOLS_BIN_DIR)/mockgen
 CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen
 
 # Image URL to use all building/pushing image targets
-IMG ?= nwoodmsft/controller:0.14
+IMG ?= nwoodmsft/controller:0.15
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	flag.IntVar(&azureStackHCIVirtualMachineConcurrency,
 		"azurestackhci-virtual-machine-concurrency",
-		10,
+		5,
 		"Number of AzureStackHCIVirtualMachines to process simultaneously",
 	)
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: azurestackhciclusters.infrastructure.cluster.x-k8s.io
 spec:
@@ -12,6 +14,7 @@ spec:
     - cluster-api
     kind: AzureStackHCICluster
     plural: azurestackhciclusters
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachines.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: azurestackhcimachines.infrastructure.cluster.x-k8s.io
 spec:
@@ -12,6 +14,7 @@ spec:
     - cluster-api
     kind: AzureStackHCIMachine
     plural: azurestackhcimachines
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachinetemplates.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: azurestackhcimachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
@@ -12,6 +14,7 @@ spec:
     - cluster-api
     kind: AzureStackHCIMachineTemplate
     plural: azurestackhcimachinetemplates
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcivirtualmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcivirtualmachines.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: azurestackhcivirtualmachines.infrastructure.cluster.x-k8s.io
 spec:
@@ -10,6 +12,7 @@ spec:
   names:
     kind: AzureStackHCIVirtualMachine
     plural: azurestackhcivirtualmachines
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_loadbalancer.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_loadbalancer.yaml
@@ -2,6 +2,8 @@
     apiVersion: apiextensions.k8s.io/v1beta1
     kind: CustomResourceDefinition
     metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.2.5
       creationTimestamp: null
       name: loadbalancers.infrastructure.cluster.x-k8s.io
     spec:
@@ -9,6 +11,7 @@
       names:
         kind: LoadBalancer
         plural: loadbalancers
+      preserveUnknownFields: false
       scope: Namespaced
       subresources:
         status: {}

--- a/config/default/manager_credentials_patch.yaml
+++ b/config/default/manager_credentials_patch.yaml
@@ -19,3 +19,8 @@ spec:
               secretKeyRef:
                 name: manager-bootstrap-credentials
                 key: wssd-debug-mode
+          - name: BINARY_LOCATION
+            valueFrom:
+              secretKeyRef:
+                name: manager-bootstrap-credentials
+                key: binary-location

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,7 +7,8 @@ spec:
   template:
     spec:
       containers:
-      - image: nwoodmsft/controller:0.14
+      - image: nwoodmsft/controller:0.15
         name: manager
         args:
         - "--v=6"
+        - "--metrics-addr=:8081"

--- a/config/manager/credentials.yaml
+++ b/config/manager/credentials.yaml
@@ -7,3 +7,4 @@ type: Opaque
 data:
   cloudagent-fqdn: ${CLOUDAGENT_FQDN_B64}
   wssd-debug-mode: ${WSSD_DEBUG_MODE_B64}
+  binary-location: ${BINARY_LOCATION_B64}

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -125,6 +125,9 @@ fi
 export CLOUDAGENT_FQDN_B64="$(echo -n "$CLOUDAGENT_FQDN" | base64 | tr -d '\n')"
 export WSSD_DEBUG_MODE_B64="$(echo -n "$WSSD_DEBUG_MODE" | base64 | tr -d '\n')"
 
+# Temp until lbagent work is complete.
+export BINARY_LOCATION_B64="$(echo -n "$BINARY_LOCATION" | base64 | tr -d '\n')"
+
 # Prepare environment for generation of management cluster yamls
 export CLUSTER_NAME="${MANAGEMENT_CLUSTER_NAME}"
 export LOAD_BALANCER_NAME=${MANAGEMENT_CLUSTER_LB_NAME}
@@ -167,11 +170,11 @@ kustomize build "${SOURCE_DIR}/machinedeployment" | envsubst >> "${MACHINEDEPLOY
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.4/cluster-api-components.yaml > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.10/cluster-api-components.yaml > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Downloaded ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-curl -L https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/v0.1.2/bootstrap-components.yaml > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
+curl -L https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/v0.1.6/bootstrap-components.yaml > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Downloaded ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate AzureStackHCI Infrastructure Provider components file.

--- a/examples/provider-components/kubeadm_token_patch.yaml
+++ b/examples/provider-components/kubeadm_token_patch.yaml
@@ -13,10 +13,10 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
+        - --metrics-addr=127.0.0.1:8082
         - --v=4
         - --enable-leader-election
         - --bootstrap-token-ttl=30m
-        image: us.gcr.io/k8s-artifacts-prod/capi-kubeadm/cluster-api-kubeadm-controller:v0.1.2
+        image: us.gcr.io/k8s-artifacts-prod/capi-kubeadm/cluster-api-kubeadm-controller:v0.1.6
         imagePullPolicy: Always
         name: manager

--- a/examples/provider-components/kustomization.yaml
+++ b/examples/provider-components/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - provider-components-azurestackhci.yaml
 patchesStrategicMerge:
 - manager_tolerations_patch.yaml
+- manager_networking_patch.yaml
 - kubeadm_token_patch.yaml

--- a/examples/provider-components/manager_networking_patch.yaml
+++ b/examples/provider-components/manager_networking_patch.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: cabpk-controller-manager
+    namespace: cabpk-system
+spec:
+    template:
+    spec:
+        hostNetwork: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: caph-controller-manager
+    namespace: caph-system
+spec:
+    template:
+    spec:
+        hostNetwork: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: capi-controller-manager
+    namespace: capi-system
+spec:
+    template:
+    spec:
+        hostNetwork: true

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/go-logr/logr v0.1.0
-	github.com/microsoft/cluster-api-provider-azurestackhci v0.0.10
 	github.com/microsoft/moc v0.8.0-alpha.2
 	github.com/microsoft/moc-sdk-for-go v0.8.0-alpha.2
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
Bringing in the last few changes from old repository. This moves the provider to the latest v1alpha2 release and brings in some temporary work arounds for flannel and lbagent. 

We are making this final update before cutting the v1alpha2 branch and moving master to v1alpha3.