### PR TITLE
[WIP] Template Changes to move towards less CloudInit based bootstrap

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -48,16 +48,21 @@ spec:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
           anonymous-auth: "false"
+          cloud-provider: external
     joinConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
     clusterConfiguration:
       apiServer:
         timeoutForControlPlane: 20m
+        cloud-provider: external
       controllerManager:
         extraArgs:
           terminated-pod-gc-threshold: "10"
           bind-address: "0.0.0.0"
+          cloud-provider: external
       scheduler:
         extraArgs:
           bind-address: "0.0.0.0"
@@ -279,10 +284,6 @@ spec:
         }
   
         function kubernetes_install() {
-          K8S_VERSION="${KUBERNETES_VERSION}"
-          KUBEADM_VERSION="${KUBERNETES_VERSION}"
-          # tdnf install -y kubernetes-${KUBERNETES_VERSION} kubernetes-kubeadm-${KUBERNETES_VERSION} kubernetes-pause-${KUBERNETES_VERSION}
-  
           cat > /etc/sysctl.d/90-kubelet.conf << EOF
         vm.overcommit_memory=1
         kernel.panic=10
@@ -304,14 +305,7 @@ spec:
   
         set -euxo pipefail
 
-        function flannel_install() {
-          KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f /etc/kubernetes/cni/kube-flannel.yml
-        }
 
-        function kube_proxy_install() {
-          KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f /etc/kubernetes/cni/win-kube-proxy.yaml
-        }
-  
         # Temp, this responsibility will move to caph
         function patch_node_providerid() {
           for value in {1..10}
@@ -327,8 +321,6 @@ spec:
           iptables-save > /etc/sysconfig/iptables
         }
   
-        flannel_install
-        kube_proxy_install
         save_iptables_config
         patch_node_providerid
   version: "${KUBERNETES_VERSION}"
@@ -388,6 +380,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
+          cloud-provider: external
       preKubeadmCommands:
         - bash -c /tmp/kubeadm-bootstrap.sh
       postKubeadmCommands:


### PR DESCRIPTION
Three Things:

* If we regenerate the cluster-template with an updated version of K8s, it fails KCP validation
* Add params for kubeadm to point at an external cloud provider.
* AddOns like CNI should not be installed by default. follow the other CAPI providers and allow for addons to be installed by the user in post.