### PR TITLE
Fix Cluster Delete

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"context"
+
+	infrav1 "github.com/microsoft/cluster-api-provider-azurestackhci/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetAzureStackHCIMachinesInCluster gets a cluster's AzureStackHCIMachines resources.
+func GetAzureStackHCIMachinesInCluster(ctx context.Context, controllerClient client.Client, namespace, clusterName string) ([]*infrav1.AzureStackHCIMachine, error) {
+	labels := map[string]string{clusterv1.ClusterLabelName: clusterName}
+	machineList := &infrav1.AzureStackHCIMachineList{}
+
+	if err := controllerClient.List(
+		ctx, machineList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels)); err != nil {
+		return nil, err
+	}
+
+	machines := make([]*infrav1.AzureStackHCIMachine, len(machineList.Items))
+	for i := range machineList.Items {
+		machines[i] = &machineList.Items[i]
+	}
+
+	return machines, nil
+}


### PR DESCRIPTION
Today Cluster Delete leaves leaked machines. This is because CAPH deletes the the LoadBalancer before core CAPI has the chance to finish deleting all of the machines in the cluster. 

It is crucial that CAPH keeps the API server up until all the machines are deleted. Core CAPI relies on pinging the API server to ensure that they can perform their cleanup job.