### PR TITLE
Adjusting cloud-provider configuration in cluster template

### DIFF
--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -59,13 +59,10 @@ spec:
     clusterConfiguration:
       apiServer:
         timeoutForControlPlane: 20m
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           terminated-pod-gc-threshold: "10"
           bind-address: "0.0.0.0"
-          cloud-provider: external
       scheduler:
         extraArgs:
           bind-address: "0.0.0.0"
@@ -307,8 +304,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
-          kubeletExtraArgs:
-            cloud-provider: external
       postKubeadmCommands:
         - bash -c /tmp/kubeadm-postinstall.sh
       files:


### PR DESCRIPTION
Adjusting cloud-provider configuration in cluster template. The lines being removed were causing some pods on target cluster to fail to start as cloud provider is not marked nodes as initialized.