### PR TITLE
Add Kubernetes Version to the KudeAdm Cluster Config

### DIFF
--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -141,6 +141,8 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
+    preKubeadmCommands:
+    - /etc/rc.d/init.d/docker-import-mcr-k8s.sh
     useExperimentalRetryJoin: true
     initConfiguration:
       nodeRegistration:
@@ -170,11 +172,8 @@ spec:
           bind-address: "0.0.0.0"
           leader-elect-lease-duration: "60s"
           leader-elect-renew-deadline: "55s"
-      imageRepository: "mcr.microsoft.com/oss/kubernetes"
-      etcd:
-        local:
-          imageRepository: "mcr.microsoft.com/oss/etcd-io"
-          imageTag: "v3.3.15"
+      imageRepository: "ecpacr.azurecr.io"
+      kubernetesVersion: "${KUBERNETES_VERSION}"
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3

--- a/templates/flavors/mgmt/patches/mgmt.yaml
+++ b/templates/flavors/mgmt/patches/mgmt.yaml
@@ -5,11 +5,3 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   management: true
----
-kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
-metadata:
-  name: "${CLUSTER_NAME}-control-plane"
-spec:
-  kubeadmConfigSpec:
-  version: "${KUBERNETES_VERSION}"


### PR DESCRIPTION
Without this added version in the config, kubeadm will end up pulling the latest patch image for the minor version. 

Once we add this, kubeadm will pull the exact patch we are expecting.