### PR TITLE
Only add the backend pool names one time.

### DIFF
--- a/controllers/azurestackhcimachine_controller.go
+++ b/controllers/azurestackhcimachine_controller.go
@@ -290,21 +290,23 @@ func (r *AzureStackHCIMachineReconciler) reconcileVirtualMachineNormal(machineSc
 		vm.Spec.VnetName = clusterScope.AzureStackHCICluster.Spec.NetworkSpec.Vnet.Name
 		vm.Spec.ClusterName = clusterScope.AzureStackHCICluster.Name
 
+		backendPoolNames := []string{}
 		switch role := machineScope.Role(); role {
 		case infrav1.Node:
 			vm.Spec.SubnetName = azurestackhci.GenerateNodeSubnetName(clusterScope.Name())
 		case infrav1.ControlPlane:
 			vm.Spec.SubnetName = azurestackhci.GenerateControlPlaneSubnetName(clusterScope.Name())
 			if clusterScope.AzureStackHCILoadBalancer() != nil {
-				vm.Spec.BackendPoolNames = append(vm.Spec.BackendPoolNames, azurestackhci.GenerateControlPlaneBackendPoolName(clusterScope.Name()))
+				backendPoolNames = append(backendPoolNames, azurestackhci.GenerateControlPlaneBackendPoolName(clusterScope.Name()))
 			}
 		default:
 			return errors.Errorf("unknown value %s for label `set` on machine %s, unable to create virtual machine resource", role, machineScope.Name())
 		}
 		//add worker and control plane nodes to the lb backend
 		if clusterScope.AzureStackHCILoadBalancer() != nil {
-			vm.Spec.BackendPoolNames = append(vm.Spec.BackendPoolNames, azurestackhci.GenerateBackendPoolName(clusterScope.Name()))
+			backendPoolNames = append(backendPoolNames, azurestackhci.GenerateBackendPoolName(clusterScope.Name()))
 		}
+		vm.Spec.BackendPoolNames = backendPoolNames
 
 		var bootstrapData string
 		bootstrapData, err = machineScope.GetBootstrapData()


### PR DESCRIPTION
We were constantly appending the pool names to the vm.spec which was growing unbounded, but at a pretty slow rate.  
This doesn't seem to have any functional issues.
thanks Nick for finding this.

To repro deploy a cluster and then look at the vm spec using:
```
kubectl --kubeconfig C:\wssd\kubeconfig-clustergroup-management get azurestackhcivirtualmachine/clustergroup-management-control-plane-0 -o json
```
and you'll see
```
    "spec": {
        "availabilityZone": {},
        "backendPoolNames": [
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool",
            "test-controlplane-backend-pool",
            "test-backend-pool"
        ],
```

There is a large burst at first, but then the rate slows down.
After the fix you just see:
```
    "spec": {
        "availabilityZone": {},
        "backendPoolNames": [
            "test-controlplane-backend-pool",
            "test-backend-pool"
        ],
```