### PR TITLE
Fixing Randomly Generated Tag Number

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,9 +48,10 @@ steps:
     PATH=$GOPATH_BIN:$PATH
 
     RANDOM=$$
-    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$RANDOM docker-build docker-push
-    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$RANDOM release
-    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$RANDOM generate-flavors
+    TagNum=$(( $RANDOM % 1000 ))
+    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum docker-build docker-push
+    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release
+    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum generate-flavors
   workingDirectory: '$(System.DefaultWorkingDirectory)/cluster-api-provider-azurestackhci'
   displayName: 'Build CAPH'
 
@@ -63,12 +64,13 @@ steps:
     PATH=$GOPATH_BIN:$PATH
 
     RANDOM=$$
+    TagNum=$(( $RANDOM % 1000 ))
     cp ../cluster-api-provider-azurestackhci/out/infrastructure-components.yaml deployment/infrastructure-azurestackhci/v0.3.0
     cp ../cluster-api-provider-azurestackhci/templates/cluster-template.yaml deployment/infrastructure-azurestackhci/v0.3.0
     cp ../cluster-api-provider-azurestackhci/templates/cluster-template-mgmt.yaml deployment/infrastructure-azurestackhci/v0.3.0
 
-    make IMG=mocimages.azurecr.io/cloud-operator-staging:$RANDOM docker-build docker-push
-    make IMG=mocimages.azurecr.io/cloud-operator-staging:$RANDOM release
+    make IMG=mocimages.azurecr.io/cloud-operator-staging:$TagNum docker-build docker-push
+    make IMG=mocimages.azurecr.io/cloud-operator-staging:$TagNum release
   workingDirectory: '$(System.DefaultWorkingDirectory)/cloud-operator'
   displayName: 'Build Cloud Operator'
 


### PR DESCRIPTION
The last PR was created TAG numbers which changed with every use. This results with yamls having tag'd images that do not exist.