### PR TITLE
Add "kubeadm join" retry to windows worker nodes

### DIFF
--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -170,7 +170,7 @@ spec:
         - copy C:\Users\Administrator\.ssh\authorized_keys C:\ProgramData\ssh\administrators_authorized_keys
         - icacls C:\ProgramData\ssh\administrators_authorized_keys /inheritance:r /grant "NT AUTHORITY\SYSTEM":R
       postKubeadmCommands:
-        - powershell -C "powershell C:\ECP-Cache\RetryJoinIfNecessary.ps1 > C:\tmp\retry.log 2>&1; type C:\tmp\retry.log"
+        - powershell -C "powershell C:\ECP-Cache\RetryJoinIfNecessary.ps1 > C:\tmp\retry.log 2>&1; type C:\tmp\retry.log; del C:\tmp\retry.log"
         - powershell C:\ECP-Cache\StartFlannel.ps1
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
I validated this PR following the next steps:
* Create a new node, and before its booting, pause the loadbalancer
* Login to the node using ssh, and monitor when the default "kubeadm join" finishes (the file C:\tmp\retry.log is created), without joining to the cluster
* Wait a couple of minutes, and resume the loadbalancer
The node should successfully join to the k8s cluster