### PR TITLE
Update KIND developer workflow for private staging repro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,7 @@ docker-build: manager ## Build the docker image for controller-manager
 .PHONY: docker-push
 docker-push: ## Push the docker image
 	#docker push $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	@if [ "${DOCKER_USERNAME}" ]; then docker login $(STAGING_REGISTRY) -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}; fi
 	docker push $(CONTROLLER_IMG):$(TAG)
 
 ## --------------------------------------
@@ -315,6 +316,7 @@ dev-release:
 	#$(MAKE) generate
 	$(MAKE) docker-build
 	$(MAKE) docker-push
+	@if [ "${DOCKER_USERNAME}" ]; then ./hack/for-pipeline.sh; fi
 	$(MAKE) release
 
 .PHONY: create-local-provider-repository

--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -22,6 +22,11 @@ set -o pipefail
 : "${AZURESTACKHCI_CLOUDAGENT_FQDN:?Environment variable empty or not defined.}"
 : "${AZURESTACKHCI_BINARY_LOCATION:?Environment variable empty or not defined.}"
 
+# CAPI settings.
+export CAPI_PROVIDER_BOOTSTRAP="${CAPI_PROVIDER_BOOTSTRAP:-kubeadm:v0.3.5}"
+export CAPI_PROVIDER_CONTROLPLANE="${CAPI_PROVIDER_CONTROLPLANE:-kubeadm:v0.3.5}"
+export CAPI_PROVIDER_CORE="${CAPI_PROVIDER_CORE:-cluster-api:v0.3.5}"
+
 # Cluster settings.
 export AZURESTACKHCI_CLUSTER_RESOURCE_GROUP="${AZURESTACKHCI_CLUSTER_RESOURCE_GROUP:-nickgroup}"
 export CLUSTER_NAME="${CLUSTER_NAME:-${AZURESTACKHCI_CLUSTER_RESOURCE_GROUP}-caph-test}"
@@ -76,7 +81,7 @@ make kind-reset
 make kind-create
 
 print_banner "ClusterCTL Init"
-clusterctl init --infrastructure azurestackhci
+clusterctl init --infrastructure azurestackhci --bootstrap ${CAPI_PROVIDER_BOOTSTRAP} --control-plane ${CAPI_PROVIDER_CONTROLPLANE} --core ${CAPI_PROVIDER_CORE}
 
 print_banner "Wait For CAPI Pods To Be Ready"
 kubectl wait --for=condition=Ready --timeout=5m -n capi-system pod -l cluster.x-k8s.io/provider=cluster-api


### PR DESCRIPTION
Update KIND developer workflow for private staging repro. This is used when performing the "make deployment" workflow. if the docker env variables are set, then we will docker login to the private registry and run the hack script to modify the deployment to have access to the private registry images.