### PR TITLE
Adding phases to AzureStackHciClusters

### DIFF
--- a/api/v1alpha3/azurestackhcicluster_types.go
+++ b/api/v1alpha3/azurestackhcicluster_types.go
@@ -58,6 +58,32 @@ type AzureStackHCIClusterStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
 	Ready bool `json:"ready"`
+
+	// Phase represents the current phase of cluster actuation.
+	// E.g. Pending, Running, Terminating, Failed etc.
+	// +optional
+	Phase string `json:"phase,omitempty"`
+}
+
+// SetTypedPhase sets the Phase field to the string representation of AzureStackHCIClusterPhase.
+func (c *AzureStackHCIClusterStatus) SetTypedPhase(p AzureStackHCIClusterPhase) {
+	c.Phase = string(p)
+}
+
+// GetTypedPhase attempts to parse the Phase field and return
+// the typed AzureStackHCIClusterPhase representation as described in `types.go`.
+func (c *AzureStackHCIClusterStatus) GetTypedPhase() AzureStackHCIClusterPhase {
+	switch phase := AzureStackHCIClusterPhase(c.Phase); phase {
+	case
+		AzureStackHCIClusterPhasePending,
+		AzureStackHCIClusterPhaseProvisioning,
+		AzureStackHCIClusterPhaseProvisioned,
+		AzureStackHCIClusterPhaseDeleting,
+		AzureStackHCIClusterPhaseFailed:
+		return phase
+	default:
+		return AzureStackHCIClusterPhaseUnknown
+	}
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha3/azurestackhcicluster_types.go
+++ b/api/v1alpha3/azurestackhcicluster_types.go
@@ -89,6 +89,7 @@ func (c *AzureStackHCIClusterStatus) GetTypedPhase() AzureStackHCIClusterPhase {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=azurestackhciclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="AzureStackHCICluster status such as Pending/Provisioning/Provisioned/Deleting/Failed"
 
 // AzureStackHCICluster is the Schema for the azurestackhciclusters API
 type AzureStackHCICluster struct {

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -212,3 +212,35 @@ const (
 	ValueReady                           = "true"
 	AnnotationControlPlaneReady          = "azurestackhci.cluster.sigs.k8s.io/control-plane-ready"
 )
+
+type AzureStackHCIClusterPhase string
+
+const (
+	// AzureStackHCIClusterPhasePending is the first state a Cluster is assigned by
+	// Cluster API Cluster controller after being created.
+	AzureStackHCIClusterPhasePending = AzureStackHCIClusterPhase("pending")
+
+	// AzureStackHCIClusterPhaseProvisioning is the state when the Cluster has a provider infrastructure
+	// object associated and can start provisioning.
+	AzureStackHCIClusterPhaseProvisioning = AzureStackHCIClusterPhase("provisioning")
+
+	// AzureStackHCIClusterPhaseProvisioned is the state when its
+	// infrastructure has been created and configured.
+	AzureStackHCIClusterPhaseProvisioned = AzureStackHCIClusterPhase("provisioned")
+
+	// AzureStackHCIClusterPhaseDeleting is the Cluster state when a delete
+	// request has been sent to the API Server,
+	// but its infrastructure has not yet been fully deleted.
+	AzureStackHCIClusterPhaseDeleting = AzureStackHCIClusterPhase("deleting")
+
+	// AzureStackHCIClusterPhaseFailed is the Cluster state when the system
+	// might require user intervention.
+	AzureStackHCIClusterPhaseFailed = AzureStackHCIClusterPhase("failed")
+
+	// AzureStackHCIClusterPhaseUpgrading is the Cluster state when the system
+	// is in the middle of a update.
+	AzureStackHCIClusterPhaseUpgrading = AzureStackHCIClusterPhase("upgrading")
+
+	// AzureStackHCIClusterPhaseUnknown is returned if the Cluster state cannot be determined.
+	AzureStackHCIClusterPhaseUnknown = AzureStackHCIClusterPhase("")
+)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
@@ -248,6 +248,10 @@ spec:
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/azurestackhcicluster_controller.go
+++ b/controllers/azurestackhcicluster_controller.go
@@ -64,6 +64,7 @@ func (r *AzureStackHCIClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Res
 
 	// Fetch the AzureStackHCICluster instance
 	azureStackHCICluster := &infrav1.AzureStackHCICluster{}
+
 	err := r.Get(ctx, req.NamespacedName, azureStackHCICluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -97,6 +98,8 @@ func (r *AzureStackHCIClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Res
 
 	// Always close the scope when exiting this function so we can persist any AzureStackHCIMachine changes.
 	defer func() {
+		r.reconcilePhase(clusterScope)
+
 		if err := clusterScope.Close(); err != nil && reterr == nil {
 			reterr = err
 		}
@@ -277,4 +280,24 @@ func (r *AzureStackHCIClusterReconciler) reconcileDeleteAzureStackHCILoadBalance
 	}
 
 	return nil
+}
+
+func (r *AzureStackHCIClusterReconciler) reconcilePhase(clusterScope *scope.ClusterScope) {
+	azureStackHCICluster := clusterScope.AzureStackHCICluster
+
+	if azureStackHCICluster.Status.Phase == "" {
+		azureStackHCICluster.Status.SetTypedPhase(infrav1.AzureStackHCIClusterPhasePending)
+	}
+
+	if !azureStackHCICluster.Status.Ready {
+		azureStackHCICluster.Status.SetTypedPhase(infrav1.AzureStackHCIClusterPhaseProvisioning)
+	}
+
+	if azureStackHCICluster.Status.Ready { // && azureStackHCICluster.Spec.ControlPlaneEndpoint.IsValid() {
+		azureStackHCICluster.Status.SetTypedPhase(infrav1.AzureStackHCIClusterPhaseProvisioned)
+	}
+
+	if !azureStackHCICluster.DeletionTimestamp.IsZero() {
+		azureStackHCICluster.Status.SetTypedPhase(infrav1.AzureStackHCIClusterPhaseDeleting)
+	}
 }


### PR DESCRIPTION
Adding initial phase status to AzureStackHciClusters, with current possible phases of : 
- pending
- provisioninig
- provisioned
- failed

