### PR TITLE
Create VMs with shortened computer names for Windows OS compatibility

### DIFF
--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	computerNamePrefix = "caph-"
+	computerNamePrefix = "moc-"
 	computerNameChars  = "abcdefghijklmnopqrstuvwxyz0123456789"
 	computerNameLength = 15
 )

--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -40,7 +40,7 @@ import (
 const (
 	computerNamePrefix = "caph-"
 	computerNameChars  = "abcdefghijklmnopqrstuvwxyz0123456789"
-	computerNameLength = 14
+	computerNameLength = 15
 )
 
 // Spec input specification for Get/CreateOrUpdate/Delete calls


### PR DESCRIPTION
Same PR that we had before (https://github.com/microsoft/cluster-api-provider-azurestackhci/pull/81) - bringing this back now that other components are ready for the change. 