### PR TITLE
Cleanup defer Pattern + Adding Logs

### DIFF
--- a/controllers/azurestackhciloadbalancer_controller.go
+++ b/controllers/azurestackhciloadbalancer_controller.go
@@ -340,8 +340,8 @@ func (r *AzureStackHCILoadBalancerReconciler) reconcileLoadBalancer(loadBalancer
 	return nil
 }
 
-func (r *AzureStackHCILoadBalancerReconciler) reconcileDelete(loadBalancerScope *scope.LoadBalancerScope, clusterScope *scope.ClusterScope) (_ reconcile.Result, reterr error) {
-	loadBalancerScope.Info("Handling deleted AzureStackHCILoadBalancer")
+func (r *AzureStackHCILoadBalancerReconciler) reconcileDelete(loadBalancerScope *scope.LoadBalancerScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
+	loadBalancerScope.Info("Handling deleted AzureStackHCILoadBalancer", "LoadBalancer", loadBalancerScope.AzureStackHCILoadBalancer.Name)
 
 	if err := r.reconcileDeleteLoadBalancer(loadBalancerScope, clusterScope); err != nil {
 		r.Recorder.Eventf(loadBalancerScope.AzureStackHCILoadBalancer, corev1.EventTypeWarning, "FailureDeleteLoadBalancer", errors.Wrapf(err, "Error deleting AzureStackHCILoadBalancer %s", loadBalancerScope.Name()).Error())
@@ -352,12 +352,7 @@ func (r *AzureStackHCILoadBalancerReconciler) reconcileDelete(loadBalancerScope 
 		return reconcile.Result{}, err
 	}
 
-	defer func() {
-		if reterr == nil {
-			// VM is deleted so remove the finalizer.
-			controllerutil.RemoveFinalizer(loadBalancerScope.AzureStackHCILoadBalancer, infrav1.AzureStackHCILoadBalancerFinalizer)
-		}
-	}()
+	controllerutil.RemoveFinalizer(loadBalancerScope.AzureStackHCILoadBalancer, infrav1.AzureStackHCILoadBalancerFinalizer)
 
 	return reconcile.Result{}, nil
 }

--- a/controllers/azurestackhcimachine_controller.go
+++ b/controllers/azurestackhcimachine_controller.go
@@ -314,19 +314,14 @@ func (r *AzureStackHCIMachineReconciler) reconcileVirtualMachineNormal(machineSc
 	return vm, nil
 }
 
-func (r *AzureStackHCIMachineReconciler) reconcileDelete(machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (_ reconcile.Result, reterr error) {
-	machineScope.Info("Handling deleted AzureStackHCIMachine")
+func (r *AzureStackHCIMachineReconciler) reconcileDelete(machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
+	machineScope.Info("Handling deleted AzureStackHCIMachine", "MachineName", machineScope.AzureStackHCIMachine.Name)
 
 	if err := r.reconcileVirtualMachineDelete(machineScope, clusterScope); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	defer func() {
-		if reterr == nil {
-			// VM is deleted so remove the finalizer.
-			controllerutil.RemoveFinalizer(machineScope.AzureStackHCIMachine, infrav1.MachineFinalizer)
-		}
-	}()
+	controllerutil.RemoveFinalizer(machineScope.AzureStackHCIMachine, infrav1.MachineFinalizer)
 
 	return reconcile.Result{}, nil
 }

--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -196,12 +196,7 @@ func (r *AzureStackHCIVirtualMachineReconciler) reconcileDelete(virtualMachineSc
 	}
 	r.Recorder.Eventf(virtualMachineScope.AzureStackHCIVirtualMachine, corev1.EventTypeNormal, "SuccessfulDeleteVM", "Success deleting AzureStackHCIVirtualMachine %s/%s", virtualMachineScope.Namespace(), virtualMachineScope.Name())
 
-	defer func() {
-		if reterr == nil {
-			// VM is deleted so remove the finalizer.
-			controllerutil.RemoveFinalizer(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VirtualMachineFinalizer)
-		}
-	}()
+	controllerutil.RemoveFinalizer(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VirtualMachineFinalizer)
 
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Trying to trace why cluster delete takes so long.

Fixing the logs and getting rid of this unneeded pattern.