### PR TITLE
Use new moc package's providerid functions.

### DIFF
--- a/controllers/azurestackhcimachine_controller.go
+++ b/controllers/azurestackhcimachine_controller.go
@@ -21,13 +21,12 @@ import (
 	"context"
 	"time"
 
-	"fmt"
-
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	infrav1 "github.com/microsoft/cluster-api-provider-azurestackhci/api/v1alpha3"
 	azurestackhci "github.com/microsoft/cluster-api-provider-azurestackhci/cloud"
 	"github.com/microsoft/cluster-api-provider-azurestackhci/cloud/scope"
+	"github.com/microsoft/moc/pkg/providerid"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -217,7 +216,7 @@ func (r *AzureStackHCIMachineReconciler) reconcileNormal(machineScope *scope.Mac
 	}
 
 	// Make sure Spec.ProviderID is always set.
-	machineScope.SetProviderID(fmt.Sprintf("moc://%s", vm.Name))
+	machineScope.SetProviderID(providerid.FormatProviderID(providerid.HostType(vm.Spec.HostType), vm.Name))
 
 	// TODO(vincepri): Remove this annotation when clusterctl is no longer relevant.
 	machineScope.SetAnnotation("cluster-api-provider-azurestackhci", "true")

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.1.0
-	github.com/microsoft/moc v0.10.8-alpha.12.0.20210413063441-d8fc6838c4b1
-	github.com/microsoft/moc-sdk-for-go v0.10.8-alpha.8.0.20210413164523-0b990b432c46
+	github.com/microsoft/moc v0.10.8-alpha.12.0.20210428012510-664c2c722996
+	github.com/microsoft/moc-sdk-for-go v0.10.8-alpha.8.0.20210428013020-9db0241a87fc
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,11 @@ github.com/microsoft/moc v0.10.6-alpha.6 h1:1hPvMXEK3Okc6rT5ryOpPM56t4D4u5v7VD9e
 github.com/microsoft/moc v0.10.6-alpha.6/go.mod h1:cIuJXU7UOjEXnHEZj8IGH4z9Lrc8lcVGp5/h+YVemec=
 github.com/microsoft/moc v0.10.8-alpha.12.0.20210413063441-d8fc6838c4b1 h1:rv0fCgeGZsFFuom+x85WBuJ7uD9VpLYz/ZwLiVhwIB8=
 github.com/microsoft/moc v0.10.8-alpha.12.0.20210413063441-d8fc6838c4b1/go.mod h1:B9W3xCoqNhfCMQ5dsQ12JOcsmG0xbpXQ8ux7u/n/rco=
+github.com/microsoft/moc v0.10.8-alpha.12.0.20210428012510-664c2c722996 h1:xAkpMHUgf/uwbLwHFcihcNA9wTxhRg2r6PMf66syIlQ=
+github.com/microsoft/moc v0.10.8-alpha.12.0.20210428012510-664c2c722996/go.mod h1:B9W3xCoqNhfCMQ5dsQ12JOcsmG0xbpXQ8ux7u/n/rco=
 github.com/microsoft/moc v0.10.8-alpha.16 h1:uRL8OcekJ6MUjJyOIwhskJ1H2T3WuZw1y94iEJakwxk=
 github.com/microsoft/moc v0.10.8-alpha.16/go.mod h1:bY29w3GntaOpAFMT7eOQb6S/X0yOMCBOkaMhwvIPoOM=
+github.com/microsoft/moc v0.10.8 h1:tA6rGLDQi2FJeDprh/igD7vOeqlU4ifKA00dVUpIoSc=
 github.com/microsoft/moc-sdk-for-go v0.10.1-alpha.1 h1:rU0ec4KfkZ2Gmw1U4Zg7gOraeEqm9a40SFWTjVs5/es=
 github.com/microsoft/moc-sdk-for-go v0.10.1-alpha.1/go.mod h1:qWMWuKLImyoYPO6vsXz21onA2AE7UaBfzaS/giQpOMU=
 github.com/microsoft/moc-sdk-for-go v0.10.6-alpha.1 h1:ss6ftjGBw+Y3AjiJKh/HNwWT5qVkirwNsaIP3UInYR4=
@@ -330,6 +333,8 @@ github.com/microsoft/moc-sdk-for-go v0.10.6-alpha.7 h1:Yv5WLjL8LBrofAqvdLbHZqXQb
 github.com/microsoft/moc-sdk-for-go v0.10.6-alpha.7/go.mod h1:cUhelJyVi1uq9lhLSY+oVvg0RHr3NUpL3mfM4ccUZSQ=
 github.com/microsoft/moc-sdk-for-go v0.10.8-alpha.8.0.20210413164523-0b990b432c46 h1:5SlGXeoZwPpWvP71Zes2npDTKDEz5dqAFoTCni2crQA=
 github.com/microsoft/moc-sdk-for-go v0.10.8-alpha.8.0.20210413164523-0b990b432c46/go.mod h1:sMH+9BdNOQzs0n9aVILkBBbfZR0yru19WMlNJ6j+ESs=
+github.com/microsoft/moc-sdk-for-go v0.10.8-alpha.8.0.20210428013020-9db0241a87fc h1:y960c8P+aQKbnmPtn2uLaUuRaa6vWZNhBLzjFVPJmiE=
+github.com/microsoft/moc-sdk-for-go v0.10.8-alpha.8.0.20210428013020-9db0241a87fc/go.mod h1:qCs+nwaqmL3m9ygpjOzegoT0S3/J/4EExOgOiRao75E=
 github.com/microsoft/moc-sdk-for-go v0.10.8 h1:RIRYwwKMsTCsWtpjDx5its7MSMtfn+YxDLzs4affUes=
 github.com/microsoft/moc-sdk-for-go v0.10.8/go.mod h1:Y6G0lF+rUkg9QwuBSdT/wzXbPdBsMhqIvdIr5SpjW8Q=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=


### PR DESCRIPTION
Use the new `providerid.FormatProviderID` function in MOC package
instead of manually formatting the provider ID. This also inherently
adds support for bare-metal provider IDs.