### PR TITLE
Delete Orphaned Machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ETCD=$(TOOLS_BIN_DIR)/etcd
 # Version
 MAJOR_VER ?= 0
 MINOR_VER ?= 3
-PATCH_VER ?= 9-alpha
+PATCH_VER ?= 10-alpha
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= mocimages.azurecr.io

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -38,10 +38,10 @@ steps:
       exit 1
     fi
 
-    make REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller RELEASE_TAG=$(RELEASE_TAG) docker-build docker-push
-    make REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller RELEASE_TAG=$(RELEASE_TAG) release
-    make REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller RELEASE_TAG=$(RELEASE_TAG) generate-flavors
-    make REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller RELEASE_TAG=$(RELEASE_TAG) release-pipelines
+    make PROD_REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller TAG=$(RELEASE_TAG) docker-build docker-push
+    make PROD_REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller TAG=$(RELEASE_TAG) release
+    make PROD_REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller TAG=$(RELEASE_TAG) generate-flavors
+    make PROD_REGISTRY=ecpacr.azurecr.io IMAGE_NAME=caphcontroller TAG=$(RELEASE_TAG) release-pipelines
   workingDirectory: '$(System.DefaultWorkingDirectory)'
   displayName: 'Build CAPH'
 

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: mocimages.azurecr.io/caphcontroller:0.3.9-alpha
+      - image: mocimages.azurecr.io/caphcontroller:0.3.10-alpha
         name: manager


### PR DESCRIPTION
During cluster deletion, we can be left in a race condition which causes AzureStackHCIMachines to be created and then their parent, machine to be deleted before the parent machine can place the ownerref.

This leaves CAPH in an endless reconcile loop waiting for AzureStackHCI machines to be deleted. To break this infinite loop this change introduces a function to allow the AzureStackHCICluster controller to explicitly call delete on these orphaned resources.