### PR TITLE
Add custom VM sizes for aks-iot deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ETCD=$(TOOLS_BIN_DIR)/etcd
 # Version
 MAJOR_VER ?= 0
 MINOR_VER ?= 3
-PATCH_VER ?= 9
+PATCH_VER ?= 8-alpha
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= mocimages.azurecr.io
@@ -62,7 +62,7 @@ STAGING_REGISTRY := mocimages.azurecr.io
 PROD_REGISTRY := mocimages.azurecr.io
 IMAGE_NAME ?= caphcontroller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG := $(MAJOR_VER).$(MINOR_VER).$(PATCH_VER)-aksiot-0527
+TAG := $(shell git describe --tags)
 ARCH := amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ STAGING_REGISTRY := mocimages.azurecr.io
 PROD_REGISTRY := mocimages.azurecr.io
 IMAGE_NAME ?= caphcontroller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG := $(MAJOR_VER).$(MINOR_VER).$(PATCH_VER)
+TAG := $(MAJOR_VER).$(MINOR_VER).$(PATCH_VER)-aksiot-0527
 ARCH := amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ETCD=$(TOOLS_BIN_DIR)/etcd
 # Version
 MAJOR_VER ?= 0
 MINOR_VER ?= 3
-PATCH_VER ?= 8-alpha
+PATCH_VER ?= 9-alpha
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= mocimages.azurecr.io

--- a/Makefile
+++ b/Makefile
@@ -54,15 +54,15 @@ ETCD=$(TOOLS_BIN_DIR)/etcd
 # Version
 MAJOR_VER ?= 0
 MINOR_VER ?= 3
-PATCH_VER ?= 9-alpha
+PATCH_VER ?= 10-alpha
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= mocimages.azurecr.io
-STAGING_REGISTRY ?= mocimages.azurecr.io
-PROD_REGISTRY ?= mocimages.azurecr.io
+STAGING_REGISTRY := mocimages.azurecr.io
+PROD_REGISTRY := mocimages.azurecr.io
 IMAGE_NAME ?= caphcontroller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG := $(shell git describe --tags --abbrev=7)
+TAG := $(MAJOR_VER).$(MINOR_VER).$(PATCH_VER)
 ARCH := amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ETCD=$(TOOLS_BIN_DIR)/etcd
 # Version
 MAJOR_VER ?= 0
 MINOR_VER ?= 3
-PATCH_VER ?= 9-alpha
+PATCH_VER ?= 9
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= mocimages.azurecr.io

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ PATCH_VER ?= 8-alpha
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= mocimages.azurecr.io
-STAGING_REGISTRY := mocimages.azurecr.io
-PROD_REGISTRY := mocimages.azurecr.io
+STAGING_REGISTRY ?= mocimages.azurecr.io
+PROD_REGISTRY ?= mocimages.azurecr.io
 IMAGE_NAME ?= caphcontroller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG := $(shell git describe --tags)
+TAG := $(shell git describe --tags --abbrev=7)
 ARCH := amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 

--- a/api/v1alpha3/azurestackhcimachine_types.go
+++ b/api/v1alpha3/azurestackhcimachine_types.go
@@ -37,6 +37,7 @@ type AzureStackHCIMachineSpec struct {
 	ProviderID *string `json:"providerID,omitempty"`
 
 	VMSize string `json:"vmSize"`
+	CustomSize VirtualMachineCustomSize `json:"customSize,omitempty"`
 
 	AvailabilityZone AvailabilityZone `json:"availabilityZone,omitempty"`
 

--- a/api/v1alpha3/azurestackhcivirtualmachine_types.go
+++ b/api/v1alpha3/azurestackhcivirtualmachine_types.go
@@ -32,14 +32,15 @@ const (
 
 // AzureStackHCIVirtualMachineSpec defines the desired state of AzureStackHCIVirtualMachine
 type AzureStackHCIVirtualMachineSpec struct {
-	VMSize           string           `json:"vmSize"`
-	AvailabilityZone AvailabilityZone `json:"availabilityZone,omitempty"`
-	Image            Image            `json:"image"`
-	OSDisk           OSDisk           `json:"osDisk,omitempty"`
-	BootstrapData    *string          `json:"bootstrapData,omitempty"`
-	Identity         VMIdentity       `json:"identity,omitempty"`
-	Location         string           `json:"location"` // does location belong here?
-	SSHPublicKey     string           `json:"sshPublicKey"`
+	VMSize           string                   `json:"vmSize"`
+	CustomSize       VirtualMachineCustomSize `json:"customSize,omitempty"`
+	AvailabilityZone AvailabilityZone         `json:"availabilityZone,omitempty"`
+	Image            Image                    `json:"image"`
+	OSDisk           OSDisk                   `json:"osDisk,omitempty"`
+	BootstrapData    *string                  `json:"bootstrapData,omitempty"`
+	Identity         VMIdentity               `json:"identity,omitempty"`
+	Location         string                   `json:"location"` // does location belong here?
+	SSHPublicKey     string                   `json:"sshPublicKey"`
 
 	// come from the cluster scope for machine and lb controller creation path
 	ResourceGroup    string   `json:"resourceGroup"`

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -129,6 +129,11 @@ var (
 	VMStateUpdating = VMState("Updating")
 )
 
+type VirtualMachineCustomSize struct {
+       CpuCount int32 `json:"cpuCount,omitempty"`
+       MemoryMB int32 `json:"memoryMB,omitempty"`
+}
+
 // VM describes an Azure virtual machine.
 type VM struct {
 	ID   string `json:"id,omitempty"`
@@ -138,6 +143,7 @@ type VM struct {
 
 	// Hardware profile
 	VMSize string `json:"vmSize,omitempty"`
+	CustomSize VirtualMachineCustomSize `json:"customSize,omitempty"`
 
 	// Storage profile
 	Image  Image  `json:"image,omitempty"`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,11 @@ steps:
   inputs:
     command: login
     containerRegistry: mocimages-connection
+- task: Docker@2
+  displayName: Login to ACR
+  inputs:
+    command: login
+    containerRegistry: AKS-IOT-Preview-ACR
 - task: GoTool@0
   inputs:
     version: '1.15.x'
@@ -49,12 +54,24 @@ steps:
     GOPATH_BIN="$(go env GOPATH)/bin/"
     PATH=$GOPATH_BIN:$PATH
 
-    RANDOM=$$
-    TagNum=$(( $RANDOM % 1000 ))
-    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum docker-build docker-push
-    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release
-    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum generate-flavors
-    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release-pipelines
+    export AKSIOT_BUILD=$(AKSIOT_BUILD)
+
+    if [ -z "$AKSIOT_BUILD" ]
+    then
+      echo "Building for AksHci..."
+      RANDOM=$$
+      TagNum=$(( $RANDOM % 1000 ))
+      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum docker-build docker-push
+      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release
+      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum generate-flavors
+      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release-pipelines
+    else
+      echo "Building for AksIot..."
+      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io docker-build docker-push
+      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io release
+      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io generate-flavors
+      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io release-pipelines
+    fi
 
     sudo snap install yq
 
@@ -83,4 +100,3 @@ steps:
 
 - publish: $(System.DefaultWorkingDirectory)/templates
   artifact: templates
-  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,11 +34,6 @@ steps:
   inputs:
     command: login
     containerRegistry: mocimages-connection
-- task: Docker@2
-  displayName: Login to ACR
-  inputs:
-    command: login
-    containerRegistry: AKS-IOT-Preview-ACR
 - task: GoTool@0
   inputs:
     version: '1.15.x'
@@ -54,24 +49,12 @@ steps:
     GOPATH_BIN="$(go env GOPATH)/bin/"
     PATH=$GOPATH_BIN:$PATH
 
-    export AKSIOT_BUILD=$(AKSIOT_BUILD)
-
-    if [ -z "$AKSIOT_BUILD" ]
-    then
-      echo "Building for AksHci..."
-      RANDOM=$$
-      TagNum=$(( $RANDOM % 1000 ))
-      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum docker-build docker-push
-      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release
-      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum generate-flavors
-      make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release-pipelines
-    else
-      echo "Building for AksIot..."
-      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io docker-build docker-push
-      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io release
-      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io generate-flavors
-      make REGISTRY=aksiotpreviewacr.azurecr.io STAGING_REGISTRY=aksiotpreviewacr.azurecr.io PROD_REGISTRY=aksiotpreviewacr.azurecr.io release-pipelines
-    fi
+    RANDOM=$$
+    TagNum=$(( $RANDOM % 1000 ))
+    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum docker-build docker-push
+    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release
+    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum generate-flavors
+    make REGISTRY=mocimages.azurecr.io IMAGE_NAME=caphcontroller-staging PATCH_VER=$TagNum release-pipelines
 
     sudo snap install yq
 
@@ -100,3 +83,4 @@ steps:
 
 - publish: $(System.DefaultWorkingDirectory)/templates
   artifact: templates
+  

--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -46,8 +46,10 @@ const (
 type Spec struct {
 	Name       string
 	NICName    string
-	SSHKeyData []string
-	Size       string
+	SSHKeyData string
+	VMSize     string
+	CpuCount   int32
+	MemoryMB   int32
 	Zone       string
 	Image      infrav1.Image
 	OSDisk     infrav1.OSDisk
@@ -154,7 +156,11 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			},
 			VmType: vmSpec.VMType,
 			HardwareProfile: &compute.HardwareProfile{
-				VMSize: compute.VirtualMachineSizeTypes(vmSpec.Size),
+				VMSize: compute.VirtualMachineSizeTypes(vmSpec.VMSize),
+				CustomSize: &compute.VirtualMachineCustomSize{
+					CpuCount: &vmSpec.CpuCount,
+					MemoryMB: &vmSpec.MemoryMB,
+				},
 			},
 		},
 	}

--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -46,7 +46,7 @@ const (
 type Spec struct {
 	Name       string
 	NICName    string
-	SSHKeyData string
+	SSHKeyData []string
 	VMSize     string
 	CpuCount   int32
 	MemoryMB   int32

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
@@ -255,6 +255,15 @@ spec:
                   vmSize:
                     description: Hardware profile
                     type: string
+                  customSize:
+                    properties:
+                      cpuCount:
+                        format: int32
+                        type: integer
+                      memoryMB:
+                        format: int32
+                        type: integer
+                    type: object
                   vmState:
                     description: State - The provisioning state, which only appears
                       in the response.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachines.yaml
@@ -123,6 +123,15 @@ spec:
                 type: string
               vmSize:
                 type: string
+              customSize:
+                properties:
+                  cpuCount:
+                    format: int32
+                    type: integer
+                  memoryMB:
+                    format: int32
+                    type: integer
+                type: object
             required:
             - location
             - sshPublicKey

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachinetemplates.yaml
@@ -134,6 +134,15 @@ spec:
                         type: string
                       vmSize:
                         type: string
+                      customSize:
+                        properties:
+                          cpuCount:
+                            format: int32
+                            type: integer
+                          memoryMB:
+                            format: int32
+                            type: integer
+                        type: object
                     required:
                     - location
                     - sshPublicKey

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcivirtualmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcivirtualmachines.yaml
@@ -134,6 +134,15 @@ spec:
                 type: string
               vmSize:
                 type: string
+              customSize:
+                properties:
+                  cpuCount:
+                    format: int32
+                    type: integer
+                  memoryMB:
+                    format: int32
+                    type: integer
+                type: object
               vnetName:
                 type: string
             required:

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: mocimages.azurecr.io/caphcontroller:0.3.9-alpha
+      - image: mocimages.azurecr.io/caphcontroller:0.3.9
         name: manager

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: mocimages.azurecr.io/caphcontroller:v0.3.8-aksiot-0527
+      - image: mocimages.azurecr.io/caphcontroller:v0.3.9-aksiot-0805
         name: manager

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: mocimages.azurecr.io/caphcontroller:0.3.9
+      - image: mocimages.azurecr.io/caphcontroller:v0.3.8-aksiot-0527
         name: manager

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: mocimages.azurecr.io/caphcontroller:v0.3.9-aksiot-0805
+      - image: mocimages.azurecr.io/caphcontroller:0.3.10-alpha
         name: manager

--- a/controllers/azurestackhcimachine_controller.go
+++ b/controllers/azurestackhcimachine_controller.go
@@ -300,6 +300,8 @@ func (r *AzureStackHCIMachineReconciler) reconcileVirtualMachineNormal(machineSc
 		image.DeepCopyInto(&vm.Spec.Image)
 
 		vm.Spec.VMSize = machineScope.AzureStackHCIMachine.Spec.VMSize
+		vm.Spec.CustomSize.CpuCount = machineScope.AzureStackHCIMachine.Spec.CustomSize.CpuCount
+		vm.Spec.CustomSize.MemoryMB = machineScope.AzureStackHCIMachine.Spec.CustomSize.MemoryMB
 		machineScope.AzureStackHCIMachine.Spec.AvailabilityZone.DeepCopyInto(&vm.Spec.AvailabilityZone)
 		machineScope.AzureStackHCIMachine.Spec.OSDisk.DeepCopyInto(&vm.Spec.OSDisk)
 		vm.Spec.Location = machineScope.AzureStackHCIMachine.Spec.Location

--- a/controllers/azurestackhcivirtualmachine_reconciler.go
+++ b/controllers/azurestackhcivirtualmachine_reconciler.go
@@ -215,8 +215,10 @@ func (s *azureStackHCIVirtualMachineService) createVirtualMachine(nicName string
 		vmSpec = &virtualmachines.Spec{
 			Name:       s.vmScope.Name(),
 			NICName:    nicName,
-			SSHKeyData: decodedKeys,
-			Size:       s.vmScope.AzureStackHCIVirtualMachine.Spec.VMSize,
+			SSHKeyData: string(decoded),
+			VMSize:     s.vmScope.AzureStackHCIVirtualMachine.Spec.VMSize,
+			CpuCount:   s.vmScope.AzureStackHCIVirtualMachine.Spec.CustomSize.CpuCount,
+			MemoryMB:   s.vmScope.AzureStackHCIVirtualMachine.Spec.CustomSize.MemoryMB,
 			OSDisk:     s.vmScope.AzureStackHCIVirtualMachine.Spec.OSDisk,
 			Image:      s.vmScope.AzureStackHCIVirtualMachine.Spec.Image,
 			CustomData: *s.vmScope.AzureStackHCIVirtualMachine.Spec.BootstrapData,

--- a/controllers/azurestackhcivirtualmachine_reconciler.go
+++ b/controllers/azurestackhcivirtualmachine_reconciler.go
@@ -215,7 +215,7 @@ func (s *azureStackHCIVirtualMachineService) createVirtualMachine(nicName string
 		vmSpec = &virtualmachines.Spec{
 			Name:       s.vmScope.Name(),
 			NICName:    nicName,
-			SSHKeyData: string(decoded),
+			SSHKeyData: decodedKeys,
 			VMSize:     s.vmScope.AzureStackHCIVirtualMachine.Spec.VMSize,
 			CpuCount:   s.vmScope.AzureStackHCIVirtualMachine.Spec.CustomSize.CpuCount,
 			MemoryMB:   s.vmScope.AzureStackHCIVirtualMachine.Spec.CustomSize.MemoryMB,

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -23,6 +23,9 @@ spec:
         osType: "Linux"
       location: "westus"
       vmSize: ${AZURESTACKHCI_CONTROL_PLANE_MACHINE_TYPE}
+      customSize:
+        cpuCount: ${AZURESTACKHCI_CONTROL_PLANE_MACHINE_TYPE_CPU_COUNT}
+        memoryMB: ${AZURESTACKHCI_CONTROL_PLANE_MACHINE_TYPE_MEMORY_MB}
       sshPublicKey: ${AZURESTACKHCI_SSH_PUBLIC_KEY:=""}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3

--- a/templates/flavors/mgmt/mgmt-machine.yaml
+++ b/templates/flavors/mgmt/mgmt-machine.yaml
@@ -34,6 +34,9 @@ spec:
   providerID: moc://${CLUSTER_NAME}-control-plane-0
   sshPublicKey: ${AZURESTACKHCI_SSH_PUBLIC_KEY:=""}
   vmSize: ${AZURESTACKHCI_CONTROL_PLANE_MACHINE_TYPE}
+  customSize:
+    cpuCount: ${AZURESTACKHCI_CONTROL_PLANE_MACHINE_TYPE_CPU_COUNT}
+    memoryMB: ${AZURESTACKHCI_CONTROL_PLANE_MACHINE_TYPE_MEMORY_MB}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig


### PR DESCRIPTION
- Update structures to allow for custom VM sizes for aks-iot deployments.
- Change version to 0.3.10-alpha so to not break existing code.