### PR TITLE
Exit pod when cloudagent isn't running

### DIFF
--- a/cloud/errors.go
+++ b/cloud/errors.go
@@ -37,3 +37,11 @@ func ResourceAlreadyExists(err error) bool {
 	}
 	return false
 }
+
+func TransportUnavailable(err error) bool {
+	if e, ok := status.FromError(err); ok && e.Code() == codes.Unavailable {
+		return true
+	}
+
+	return false
+}

--- a/cloud/services/keyvaults/keyvaults.go
+++ b/cloud/services/keyvaults/keyvaults.go
@@ -19,6 +19,7 @@ package keyvaults
 
 import (
 	"context"
+	"os"
 
 	azurestackhci "github.com/microsoft/cluster-api-provider-azurestackhci/cloud"
 	"github.com/microsoft/moc-sdk-for-go/services/security"
@@ -38,11 +39,19 @@ func (s *Service) Get(ctx context.Context, spec interface{}) (interface{}, error
 		return security.KeyVault{}, errors.New("Invalid keyvault specification")
 	}
 	vault, err := s.Client.Get(ctx, s.Scope.GetResourceGroup(), vaultSpec.Name)
-	if err != nil && azurestackhci.ResourceNotFound(err) {
-		return nil, errors.Wrapf(err, "keyvault %s not found", vaultSpec.Name)
-	} else if err != nil {
+	if err != nil {
+		if azurestackhci.TransportUnavailable(err) {
+			klog.Error("Communication with cloud agent failed. Exiting Process.")
+			os.Exit(1)
+		}
+
+		if azurestackhci.ResourceNotFound(err) {
+			return nil, errors.Wrapf(err, "keyvault %s not found", vaultSpec.Name)
+		}
+
 		return nil, err
 	}
+
 	return (*vault)[0], nil
 }
 
@@ -65,6 +74,11 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			KeyVaultProperties: &security.KeyVaultProperties{},
 		})
 	if err != nil {
+		if azurestackhci.TransportUnavailable(err) {
+			klog.Error("Communication with cloud agent failed. Exiting Process.")
+			os.Exit(1)
+		}
+
 		return err
 	}
 
@@ -80,11 +94,17 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	}
 	klog.V(2).Infof("deleting keyvault %s", vaultSpec.Name)
 	err := s.Client.Delete(ctx, s.Scope.GetResourceGroup(), vaultSpec.Name)
-	if err != nil && azurestackhci.ResourceNotFound(err) {
-		// already deleted
-		return nil
-	}
 	if err != nil {
+		if azurestackhci.TransportUnavailable(err) {
+			klog.Error("Communication with cloud agent failed. Exiting Process.")
+			os.Exit(1)
+		}
+
+		if azurestackhci.ResourceNotFound(err) {
+			// already deleted
+			return nil
+		}
+
 		return errors.Wrapf(err, "failed to delete keyvault %s in resource group %s", vaultSpec.Name, s.Scope.GetResourceGroup())
 	}
 

--- a/cloud/services/virtualmachines/service.go
+++ b/cloud/services/virtualmachines/service.go
@@ -20,8 +20,8 @@ package virtualmachines
 import (
 	azurestackhci "github.com/microsoft/cluster-api-provider-azurestackhci/cloud"
 	"github.com/microsoft/cluster-api-provider-azurestackhci/cloud/scope"
-	"github.com/microsoft/moc/pkg/auth"
 	"github.com/microsoft/moc-sdk-for-go/services/compute/virtualmachine"
+	"github.com/microsoft/moc/pkg/auth"
 )
 
 var _ azurestackhci.Service = (*Service)(nil)


### PR DESCRIPTION
WorkItem: https://microsoft.visualstudio.com/OS/_workitems/edit/38182743
Test:
  - Installed/Ran AKS HCI locally, stopped the cloud agent and confirmed
    that any communication between CAPH and cloudagent would result in
    the pod exiting.