### PR TITLE
skip reconciliation when replica count is 0

### DIFF
--- a/controllers/azurestackhciloadbalancer_controller.go
+++ b/controllers/azurestackhciloadbalancer_controller.go
@@ -201,7 +201,7 @@ func (r *AzureStackHCILoadBalancerReconciler) reconcileNormal(lbs *scope.LoadBal
 		}
 	}
 
-	if lbs.GetReadyReplicas() < 1 {
+	if lbs.GetReplicas() != 0 && lbs.GetReadyReplicas() < 1 {
 		if lbs.GetReady() {
 			// we achieved ready state at any earlier point, but have now lost all ready replicas
 			r.Recorder.Eventf(lbs.AzureStackHCILoadBalancer, corev1.EventTypeWarning, "FailureLBNoReadyReplicas", "No replicas are ready for LoadBalancer %s", lbs.Name())


### PR DESCRIPTION
When SDN integration is present, NeworkController will provide loadbalancing and lb vm replica count will be set 0. In this case skip reconciliation. 

Doc https://github.com/microsoft/AKS-Edge-Docs/pull/125
Powershell changes - https://dev.azure.com/msazure/msk8s/_git/cloudmanager/pullrequest/6409352
Cloud operator changes - https://msazure.visualstudio.com/DefaultCollection/msk8s/_git/cloud-operator/pullrequest/6247655
