### PR TITLE
Moc group creation

### DIFF
--- a/cloud/services/groups/groups.go
+++ b/cloud/services/groups/groups.go
@@ -26,6 +26,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	TagKeyClusterGroup = "createdBy"
+	TagValClusterGroup = "cloud-operator"
+)
+
 // Spec specification for group
 type Spec struct {
 	Name     string
@@ -49,6 +54,7 @@ func (s *Service) Get(ctx context.Context, spec interface{}) (interface{}, error
 
 // Reconcile gets/creates/updates a group.
 func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
+
 	groupSpec, ok := spec.(*Spec)
 	if !ok {
 		return errors.New("Invalid group specification")
@@ -58,37 +64,57 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		// group already exists, cannot update since its immutable
 		return nil
 	}
+	//adding tag to group
+	tag := make(map[string]*string, 1)
+	cloudop := TagValClusterGroup
+	tag[TagKeyClusterGroup] = &cloudop
 
-	klog.V(2).Infof("creating group %s in location %s", groupSpec.Name, groupSpec.Location)
+	klog.V(2).Infof(" DEBUG creating group %s in location %s with tag %v", groupSpec.Name, groupSpec.Location, tag)
 	_, err := s.Client.CreateOrUpdate(ctx, groupSpec.Location, groupSpec.Name,
 		&cloud.Group{
 			Name:     &groupSpec.Name,
 			Location: &groupSpec.Location,
+			Tags:     tag,
 		})
 	if err != nil {
 		return err
 	}
 
-	klog.V(2).Infof("successfully created group %s", groupSpec.Name)
+	klog.V(2).Infof("DEBUG successfully created group %s", groupSpec.Name)
 	return err
 }
 
-// Delete deletes a group.
+// Delete deletes a group if group is created by cloud operator
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
+	klog.V(2).Infof("DEBUG Deleting group")
 	groupSpec, ok := spec.(*Spec)
 	if !ok {
 		return errors.New("Invalid group specification")
 	}
-	klog.V(2).Infof("deleting group %s in location %s", groupSpec.Name, groupSpec.Location)
-	err := s.Client.Delete(ctx, groupSpec.Location, groupSpec.Name)
+	group, err := s.Client.Get(ctx, groupSpec.Location, groupSpec.Name)
 	if err != nil && azurestackhci.ResourceNotFound(err) {
-		// already deleted
+		// ignoring the NotFound error, since it might be already deleted
+		klog.V(2).Infof("DEBUG group %s not found in location %s", groupSpec.Name, groupSpec.Location)
 		return nil
+	} else if err != nil {
+		return err
 	}
-	if err != nil {
-		return errors.Wrapf(err, "failed to delete group %s", groupSpec.Name)
+	groupObj := (*group)[0]
+	klog.V(2).Infof("DEBUG Got group spec", "Group Spec", groupObj)
+	value, ok := groupObj.Tags[TagKeyClusterGroup]
+	// delete only if created by cloud operator
+	if ok && (value != nil && *value == TagValClusterGroup) {
+		err := s.Client.Delete(ctx, groupSpec.Location, groupSpec.Name)
+		if err != nil && azurestackhci.ResourceNotFound(err) {
+			// already deleted
+			return nil
+		}
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete group %s", groupSpec.Name)
+		}
+		klog.V(2).Infof("DEBUG successfully deleted group %s", groupSpec.Name)
+	} else {
+		klog.V(2).Infof("DEBUG skipping group %s deletion, since it is not created by cloud operator", groupSpec.Name)
 	}
-
-	klog.V(2).Infof("successfully deleted group %s", groupSpec.Name)
 	return err
 }

--- a/cloud/services/groups/groups.go
+++ b/cloud/services/groups/groups.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	TagKeyClusterGroup = "createdBy"
+	TagKeyClusterGroup = "ownedBy"
 	TagValClusterGroup = "caph"
 )
 
@@ -65,8 +65,8 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	}
 	//adding tag to group
 	tag := make(map[string]*string, 1)
-	cloudop := TagValClusterGroup
-	tag[TagKeyClusterGroup] = &cloudop
+	caphVal := TagValClusterGroup
+	tag[TagKeyClusterGroup] = &caphVal
 
 	klog.V(2).Infof("creating group %s in location %s", groupSpec.Name, groupSpec.Location)
 	_, err := s.Client.CreateOrUpdate(ctx, groupSpec.Location, groupSpec.Name,
@@ -82,7 +82,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	return err
 }
 
-// Delete deletes a group if group is created by cloud operator
+// Delete deletes a group if group is created by caph
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	groupSpec, ok := spec.(*Spec)
 	if !ok {
@@ -99,7 +99,7 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	}
 	groupObj := (*group)[0]
 	value, ok := groupObj.Tags[TagKeyClusterGroup]
-	// delete only if created by cloud operator
+	// delete only if created by caph
 	if ok && (value != nil && *value == TagValClusterGroup) {
 		err := s.Client.Delete(ctx, groupSpec.Location, groupSpec.Name)
 		if err != nil && azurestackhci.ResourceNotFound(err) {
@@ -111,7 +111,7 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 		}
 		klog.V(2).Infof("successfully deleted group %s", groupSpec.Name)
 	} else {
-		klog.V(2).Infof("skipping group %s deletion, since it is not created by cloud operator", groupSpec.Name)
+		klog.V(2).Infof("skipping group %s deletion, since it is not created by caph", groupSpec.Name)
 	}
 	return err
 }

--- a/cloud/services/groups/groups.go
+++ b/cloud/services/groups/groups.go
@@ -69,7 +69,6 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	cloudop := TagValClusterGroup
 	tag[TagKeyClusterGroup] = &cloudop
 
-	klog.V(2).Infof(" DEBUG creating group %s in location %s with tag %v", groupSpec.Name, groupSpec.Location, tag)
 	_, err := s.Client.CreateOrUpdate(ctx, groupSpec.Location, groupSpec.Name,
 		&cloud.Group{
 			Name:     &groupSpec.Name,
@@ -79,14 +78,12 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	klog.V(2).Infof("DEBUG successfully created group %s", groupSpec.Name)
+	klog.V(2).Infof("successfully created group %s", groupSpec.Name)
 	return err
 }
 
 // Delete deletes a group if group is created by cloud operator
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
-	klog.V(2).Infof("DEBUG Deleting group")
 	groupSpec, ok := spec.(*Spec)
 	if !ok {
 		return errors.New("Invalid group specification")
@@ -94,13 +91,12 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	group, err := s.Client.Get(ctx, groupSpec.Location, groupSpec.Name)
 	if err != nil && azurestackhci.ResourceNotFound(err) {
 		// ignoring the NotFound error, since it might be already deleted
-		klog.V(2).Infof("DEBUG group %s not found in location %s", groupSpec.Name, groupSpec.Location)
+		klog.V(2).Infof("group %s not found in location %s", groupSpec.Name, groupSpec.Location)
 		return nil
 	} else if err != nil {
 		return err
 	}
 	groupObj := (*group)[0]
-	klog.V(2).Infof("DEBUG Got group spec", "Group Spec", groupObj)
 	value, ok := groupObj.Tags[TagKeyClusterGroup]
 	// delete only if created by cloud operator
 	if ok && (value != nil && *value == TagValClusterGroup) {
@@ -112,9 +108,9 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete group %s", groupSpec.Name)
 		}
-		klog.V(2).Infof("DEBUG successfully deleted group %s", groupSpec.Name)
+		klog.V(2).Infof("successfully deleted group %s", groupSpec.Name)
 	} else {
-		klog.V(2).Infof("DEBUG skipping group %s deletion, since it is not created by cloud operator", groupSpec.Name)
+		klog.V(2).Infof("skipping group %s deletion, since it is not created by cloud operator", groupSpec.Name)
 	}
 	return err
 }

--- a/cloud/services/groups/groups.go
+++ b/cloud/services/groups/groups.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	TagKeyClusterGroup = "createdBy"
-	TagValClusterGroup = "cloud-operator"
+	TagValClusterGroup = "caph"
 )
 
 // Spec specification for group

--- a/cloud/services/groups/groups.go
+++ b/cloud/services/groups/groups.go
@@ -54,7 +54,6 @@ func (s *Service) Get(ctx context.Context, spec interface{}) (interface{}, error
 
 // Reconcile gets/creates/updates a group.
 func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
-
 	groupSpec, ok := spec.(*Spec)
 	if !ok {
 		return errors.New("Invalid group specification")
@@ -69,6 +68,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	cloudop := TagValClusterGroup
 	tag[TagKeyClusterGroup] = &cloudop
 
+	klog.V(2).Infof("creating group %s in location %s", groupSpec.Name, groupSpec.Location)
 	_, err := s.Client.CreateOrUpdate(ctx, groupSpec.Location, groupSpec.Name,
 		&cloud.Group{
 			Name:     &groupSpec.Name,
@@ -88,6 +88,7 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	if !ok {
 		return errors.New("Invalid group specification")
 	}
+	klog.V(2).Infof("deleting group %s in location %s", groupSpec.Name, groupSpec.Location)
 	group, err := s.Client.Get(ctx, groupSpec.Location, groupSpec.Name)
 	if err != nil && azurestackhci.ResourceNotFound(err) {
 		// ignoring the NotFound error, since it might be already deleted

--- a/controllers/azurestackhcicluster_reconciler.go
+++ b/controllers/azurestackhcicluster_reconciler.go
@@ -33,7 +33,6 @@ import (
 const (
 	KubeConfigSecretName    = "kubeconf" // lgtm - Semmle Suppression [SM03415] Not a secret
 	KubeConfigDataFieldName = "value"
-	MocLocation             = "MocLocation"
 )
 
 // azureStackHCIClusterReconciler are list of services required by cluster controller
@@ -58,8 +57,8 @@ func newAzureStackHCIClusterReconciler(scope *scope.ClusterScope) *azureStackHCI
 
 // Reconcile reconciles all the services in pre determined order
 func (r *azureStackHCIClusterReconciler) Reconcile() error {
-	//TODO: remove DEBUG from logs
-	klog.V(2).Infof("DEBUG reconciling cluster %s", r.scope.Name())
+
+	klog.V(2).Infof("reconciling cluster %s", r.scope.Name())
 
 	r.createOrUpdateVnetName()
 
@@ -77,14 +76,13 @@ func (r *azureStackHCIClusterReconciler) Reconcile() error {
 		return errors.Wrapf(err, "failed to reconcile virtual network for cluster %s", r.scope.Name())
 	}
 
-	klog.V(2).Infof("DEBUG reconciling group cluster %s", r.scope.GetResourceGroup())
 	groupSpec := &groups.Spec{
 		Name:     r.scope.GetResourceGroup(),
-		Location: MocLocation,
+		Location: r.scope.Location(),
 	}
 
 	if err := r.groupSvc.Reconcile(r.scope.Context, groupSpec); err != nil {
-		return errors.Wrapf(err, "DEBUG failed to reconcile group for cluster %s", r.scope.Name())
+		return errors.Wrapf(err, "failed to reconcile group for cluster %s", r.scope.Name())
 	}
 
 	vaultSpec := &keyvaults.Spec{
@@ -99,7 +97,7 @@ func (r *azureStackHCIClusterReconciler) Reconcile() error {
 
 // Delete reconciles all the services in pre determined order
 func (r *azureStackHCIClusterReconciler) Delete() error {
-	klog.V(2).Infof("DEBUG deleting cluster %s", r.scope.Name())
+	klog.V(2).Infof(" deleting cluster %s", r.scope.Name())
 	vaultSpec := &keyvaults.Spec{
 		Name: r.scope.Name(),
 	}
@@ -108,10 +106,9 @@ func (r *azureStackHCIClusterReconciler) Delete() error {
 			return errors.Wrapf(err, "failed to delete keyvault %s for cluster %s", r.scope.Name(), r.scope.Name())
 		}
 	}
-	klog.V(2).Infof("DEBUG deleting group %s", r.scope.GetResourceGroup())
 	groupSpec := &groups.Spec{
 		Name:     r.scope.GetResourceGroup(),
-		Location: MocLocation,
+		Location: r.scope.Location(),
 	}
 
 	if err := r.groupSvc.Delete(r.scope.Context, groupSpec); err != nil {

--- a/controllers/azurestackhcicluster_reconciler.go
+++ b/controllers/azurestackhcicluster_reconciler.go
@@ -80,7 +80,7 @@ func (r *azureStackHCIClusterReconciler) Reconcile() error {
 		Name:     r.scope.GetResourceGroup(),
 		Location: r.scope.Location(),
 	}
-
+	// creates a group with tag as "ownedBy: caph"
 	if err := r.groupSvc.Reconcile(r.scope.Context, groupSpec); err != nil {
 		return errors.Wrapf(err, "failed to reconcile group for cluster %s", r.scope.Name())
 	}
@@ -111,6 +111,8 @@ func (r *azureStackHCIClusterReconciler) Delete() error {
 		Location: r.scope.Location(),
 	}
 
+	// a group is deleted only if it was created by azureStackHCIClusterReconciler
+	// which has tag "ownedBy: caph"
 	if err := r.groupSvc.Delete(r.scope.Context, groupSpec); err != nil {
 		return errors.Wrapf(err, "failed to delete group %s for cluster %s", r.scope.GetResourceGroup(), r.scope.Name())
 	}


### PR DESCRIPTION
Currently when a cluster is created using akshci cli, we create MocGroup in kva. This is fine since the cluster name is known beforehand and we can create moc group as clustergroup-<clustername>. 
When az cli is used for cluster creation, actual cluster name given in cli is different from the one created. This because we add a random number (azure UUID) in the end, for example: clustername-<azure id>. So, in this case we cannot create the moc group beforehand. We want moc group to be created by lower layers therefore we are introducing it in CAPI layer.