### PR TITLE
Ensure imageName is not empty for custom image

### DIFF
--- a/controllers/azurestackhciloadbalancer_virtualmachine.go
+++ b/controllers/azurestackhciloadbalancer_virtualmachine.go
@@ -257,7 +257,7 @@ func (r *AzureStackHCILoadBalancerReconciler) selectVirtualMachineForScaleDown(l
 // getVMImage returns the image to use for a virtual machine
 func (r *AzureStackHCILoadBalancerReconciler) getVMImage(loadBalancerScope *scope.LoadBalancerScope) (*infrav1.Image, error) {
 	// Use custom image if provided
-	if loadBalancerScope.AzureStackHCILoadBalancer.Spec.Image.Name != nil {
+	if loadBalancerScope.AzureStackHCILoadBalancer.Spec.Image.Name != nil && *loadBalancerScope.AzureStackHCILoadBalancer.Spec.Image.Name != "" {
 		loadBalancerScope.Info("Using custom image name for loadbalancer", "loadbalancer", loadBalancerScope.AzureStackHCILoadBalancer.GetName(), "imageName", loadBalancerScope.AzureStackHCILoadBalancer.Spec.Image.Name)
 		return &loadBalancerScope.AzureStackHCILoadBalancer.Spec.Image, nil
 	}


### PR DESCRIPTION
Making the getVMImage logic consistent with 
https://github.com/microsoft/cluster-api-provider-azurestackhci/blob/922043bea4532118bb0322e015ee653aad1b0209/controllers/azurestackhcimachine_controller.go#L414