### PR TITLE
Move AlreadyExists Catch from CreateOrUpdate to inside reconcileVirtualMachineNormal and continue

### DIFF
--- a/controllers/azurestackhcimachine_controller.go
+++ b/controllers/azurestackhcimachine_controller.go
@@ -321,7 +321,9 @@ func (r *AzureStackHCIMachineReconciler) reconcileVirtualMachineNormal(machineSc
 		//
 		// We believe this is ok as this cache issue is only going to be seen very close to when the object was
 		// initially created. We are also looking to improve this behavior by introducing live clients or polling.
-		if !apierrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
+			machineScope.Info("CreateOrUpdate in reconcileVirtualMachineNormal returned AlreadyExists", "vmName", vm.Name)
+		} else {
 			return nil, errors.Wrapf(err, "failed to CreateOrUpdate AzureStackHCIVirtualMachine %s", vm.Name)
 		}
 	}


### PR DESCRIPTION
Today in the code, we check the error returned by reconcileVirtualMachineNormal and end the reconcile loop if it is AlreadyExists.

This is incorrect behavior and forces us to wait for periodic reconcile to finish processing the machine object. To fix this we are moving the AlreadyExists error check into reconcileVirtualMachineNormal and instead of ignoring the error and ending the reconcile, we are ignoring and continuing.

There is also of other context regarding the background of when CreateOrUpgrade can return AlreadyExists that we are still looking into and will iterate on in a future PR.