### PR TITLE
Support Non-Default StorageContainer

### DIFF
--- a/api/v1beta1/azurestackhciloadbalancer_types.go
+++ b/api/v1beta1/azurestackhciloadbalancer_types.go
@@ -33,6 +33,9 @@ type AzureStackHCILoadBalancerSpec struct {
 	Image        Image  `json:"image"`
 	VMSize       string `json:"vmSize"`
 
+	// +optional
+	StorageContainer string `json:"storageContainer"`
+
 	// Number of desired loadbalancer machines. Defaults to 1.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// +optional

--- a/api/v1beta1/azurestackhcimachine_types.go
+++ b/api/v1beta1/azurestackhcimachine_types.go
@@ -48,6 +48,9 @@ type AzureStackHCIMachineSpec struct {
 
 	SSHPublicKey string `json:"sshPublicKey"`
 
+	// +optional
+	StorageContainer string `json:"storageContainer"`
+
 	// AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
 	// +optional
 	AllocatePublicIP bool `json:"allocatePublicIP,omitempty"`

--- a/api/v1beta1/azurestackhcivirtualmachine_types.go
+++ b/api/v1beta1/azurestackhcivirtualmachine_types.go
@@ -41,6 +41,9 @@ type AzureStackHCIVirtualMachineSpec struct {
 	Location         string           `json:"location"` // does location belong here?
 	SSHPublicKey     string           `json:"sshPublicKey"`
 
+	// +optional
+	StorageContainer string `json:"storageContainer"`
+
 	// come from the cluster scope for machine and lb controller creation path
 	ResourceGroup    string   `json:"resourceGroup"`
 	VnetName         string   `json:"vnetName"`

--- a/cloud/scope/virtualmachine.go
+++ b/cloud/scope/virtualmachine.go
@@ -149,6 +149,11 @@ func (m *VirtualMachineScope) Name() string {
 	return m.AzureStackHCIVirtualMachine.Name
 }
 
+// StorageContainer returns the AzureStackHCIVirtualMachine storage container
+func (m *VirtualMachineScope) StorageContainer() string {
+	return m.AzureStackHCIVirtualMachine.Spec.StorageContainer
+}
+
 // Namespace returns the namespace name.
 func (m *VirtualMachineScope) Namespace() string {
 	return m.AzureStackHCIVirtualMachine.Namespace

--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -45,15 +45,16 @@ const (
 
 // Spec input specification for Get/CreateOrUpdate/Delete calls
 type Spec struct {
-	Name       string
-	NICName    string
-	SSHKeyData []string
-	Size       string
-	Zone       string
-	Image      infrav1.Image
-	OSDisk     infrav1.OSDisk
-	CustomData string
-	VMType     compute.VMType
+	Name             string
+	NICName          string
+	SSHKeyData       []string
+	Size             string
+	Zone             string
+	Image            infrav1.Image
+	OSDisk           infrav1.OSDisk
+	CustomData       string
+	VMType           compute.VMType
+	StorageContainer string
 }
 
 // Get provides information about a virtual machine.
@@ -233,9 +234,10 @@ func generateStorageProfile(vmSpec Spec) (*compute.StorageProfile, error) {
 	}
 
 	storageProfile := &compute.StorageProfile{
-		OsDisk:         osDisk,
-		DataDisks:      &dataDisks,
-		ImageReference: imageRef,
+		OsDisk:                osDisk,
+		DataDisks:             &dataDisks,
+		ImageReference:        imageRef,
+		VmConfigContainerName: &vmSpec.StorageContainer,
 	}
 
 	return storageProfile, nil

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciclusters.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: azurestackhciclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -688,6 +687,8 @@ spec:
                     type: integer
                   sshPublicKey:
                     type: string
+                  storageContainer:
+                    type: string
                   vmSize:
                     type: string
                 required:
@@ -915,9 +916,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciloadbalancers.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhciloadbalancers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: azurestackhciloadbalancers.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -548,6 +547,8 @@ spec:
                 type: integer
               sshPublicKey:
                 type: string
+              storageContainer:
+                type: string
               vmSize:
                 type: string
             required:
@@ -675,9 +676,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachines.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: azurestackhcimachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -88,32 +87,6 @@ spec:
                 type: object
               location:
                 type: string
-              networkInterfaces:
-                items:
-                  properties:
-                    ipConfigurations:
-                      items:
-                        properties:
-                          allocation:
-                            format: int32
-                            type: integer
-                          gateway:
-                            type: string
-                          ipaddress:
-                            description: below fields are unused, but adding for completeness
-                            type: string
-                          name:
-                            type: string
-                          prefixlength:
-                            type: string
-                          primary:
-                            type: boolean
-                          subnetid:
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                type: array
               osDisk:
                 properties:
                   diskSizeGB:
@@ -332,32 +305,6 @@ spec:
                 type: object
               location:
                 type: string
-              networkInterfaces:
-                items:
-                  properties:
-                    ipConfigurations:
-                      items:
-                        properties:
-                          allocation:
-                            format: int32
-                            type: integer
-                          gateway:
-                            type: string
-                          ipaddress:
-                            description: below fields are unused, but adding for completeness
-                            type: string
-                          name:
-                            type: string
-                          prefixlength:
-                            type: string
-                          primary:
-                            type: boolean
-                          subnetid:
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                type: array
               osDisk:
                 properties:
                   diskSizeGB:
@@ -587,19 +534,21 @@ spec:
                             type: integer
                           gateway:
                             type: string
-                          ipaddress:
+                          ipAddress:
                             description: below fields are unused, but adding for completeness
                             type: string
                           name:
                             type: string
-                          prefixlength:
+                          prefixLength:
                             type: string
                           primary:
                             type: boolean
-                          subnetid:
+                          subnetId:
                             type: string
                         type: object
                       type: array
+                    name:
+                      type: string
                   type: object
                 type: array
               osDisk:
@@ -633,6 +582,8 @@ spec:
                   cloud provider.
                 type: string
               sshPublicKey:
+                type: string
+              storageContainer:
                 type: string
               vmSize:
                 type: string
@@ -750,9 +701,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcimachinetemplates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: azurestackhcimachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -99,33 +98,6 @@ spec:
                         type: object
                       location:
                         type: string
-                      networkInterfaces:
-                        items:
-                          properties:
-                            ipConfigurations:
-                              items:
-                                properties:
-                                  allocation:
-                                    format: int32
-                                    type: integer
-                                  gateway:
-                                    type: string
-                                  ipaddress:
-                                    description: below fields are unused, but adding
-                                      for completeness
-                                    type: string
-                                  name:
-                                    type: string
-                                  prefixlength:
-                                    type: string
-                                  primary:
-                                    type: boolean
-                                  subnetid:
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
                       osDisk:
                         properties:
                           diskSizeGB:
@@ -256,33 +228,6 @@ spec:
                         type: object
                       location:
                         type: string
-                      networkInterfaces:
-                        items:
-                          properties:
-                            ipConfigurations:
-                              items:
-                                properties:
-                                  allocation:
-                                    format: int32
-                                    type: integer
-                                  gateway:
-                                    type: string
-                                  ipaddress:
-                                    description: below fields are unused, but adding
-                                      for completeness
-                                    type: string
-                                  name:
-                                    type: string
-                                  prefixlength:
-                                    type: string
-                                  primary:
-                                    type: boolean
-                                  subnetid:
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        type: array
                       osDisk:
                         properties:
                           diskSizeGB:
@@ -424,20 +369,22 @@ spec:
                                     type: integer
                                   gateway:
                                     type: string
-                                  ipaddress:
+                                  ipAddress:
                                     description: below fields are unused, but adding
                                       for completeness
                                     type: string
                                   name:
                                     type: string
-                                  prefixlength:
+                                  prefixLength:
                                     type: string
                                   primary:
                                     type: boolean
-                                  subnetid:
+                                  subnetId:
                                     type: string
                                 type: object
                               type: array
+                            name:
+                              type: string
                           type: object
                         type: array
                       osDisk:
@@ -472,6 +419,8 @@ spec:
                         type: string
                       sshPublicKey:
                         type: string
+                      storageContainer:
+                        type: string
                       vmSize:
                         type: string
                     required:
@@ -488,9 +437,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcivirtualmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azurestackhcivirtualmachines.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: azurestackhcivirtualmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -97,32 +96,6 @@ spec:
                 type: object
               location:
                 type: string
-              networkInterfaces:
-                items:
-                  properties:
-                    ipConfigurations:
-                      items:
-                        properties:
-                          allocation:
-                            format: int32
-                            type: integer
-                          gateway:
-                            type: string
-                          ipaddress:
-                            description: below fields are unused, but adding for completeness
-                            type: string
-                          name:
-                            type: string
-                          prefixlength:
-                            type: string
-                          primary:
-                            type: boolean
-                          subnetid:
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                type: array
               osDisk:
                 properties:
                   diskSizeGB:
@@ -336,32 +309,6 @@ spec:
                 type: object
               location:
                 type: string
-              networkInterfaces:
-                items:
-                  properties:
-                    ipConfigurations:
-                      items:
-                        properties:
-                          allocation:
-                            format: int32
-                            type: integer
-                          gateway:
-                            type: string
-                          ipaddress:
-                            description: below fields are unused, but adding for completeness
-                            type: string
-                          name:
-                            type: string
-                          prefixlength:
-                            type: string
-                          primary:
-                            type: boolean
-                          subnetid:
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                type: array
               osDisk:
                 properties:
                   diskSizeGB:
@@ -586,19 +533,21 @@ spec:
                             type: integer
                           gateway:
                             type: string
-                          ipaddress:
+                          ipAddress:
                             description: below fields are unused, but adding for completeness
                             type: string
                           name:
                             type: string
-                          prefixlength:
+                          prefixLength:
                             type: string
                           primary:
                             type: boolean
-                          subnetid:
+                          subnetId:
                             type: string
                         type: object
                       type: array
+                    name:
+                      type: string
                   type: object
                 type: array
               osDisk:
@@ -632,6 +581,8 @@ spec:
                   creation path
                 type: string
               sshPublicKey:
+                type: string
+              storageContainer:
                 type: string
               subnetName:
                 type: string
@@ -735,9 +686,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/controllers/azurestackhciloadbalancer_virtualmachine.go
+++ b/controllers/azurestackhciloadbalancer_virtualmachine.go
@@ -181,6 +181,7 @@ func (r *AzureStackHCILoadBalancerReconciler) createOrUpdateVirtualMachine(loadB
 		vm.Spec.VMSize = loadBalancerScope.AzureStackHCILoadBalancer.Spec.VMSize
 		vm.Spec.Location = clusterScope.Location()
 		vm.Spec.SSHPublicKey = loadBalancerScope.AzureStackHCILoadBalancer.Spec.SSHPublicKey
+		vm.Spec.StorageContainer = loadBalancerScope.AzureStackHCILoadBalancer.Spec.StorageContainer
 
 		image, err := r.getVMImage(loadBalancerScope)
 		if err != nil {

--- a/controllers/azurestackhcimachine_controller.go
+++ b/controllers/azurestackhcimachine_controller.go
@@ -303,6 +303,7 @@ func (r *AzureStackHCIMachineReconciler) reconcileVirtualMachineNormal(machineSc
 		vm.Spec.SSHPublicKey = machineScope.AzureStackHCIMachine.Spec.SSHPublicKey
 		vm.Spec.BootstrapData = &bootstrapData
 		vm.Spec.AdditionalSSHKeys = machineScope.AzureStackHCIMachine.Spec.AdditionalSSHKeys
+		vm.Spec.StorageContainer = machineScope.AzureStackHCIMachine.Spec.StorageContainer
 
 		machineScope.AzureStackHCIMachine.Spec.NetworkInterfaces.DeepCopyInto(&vm.Spec.NetworkInterfaces)
 

--- a/controllers/azurestackhcivirtualmachine_reconciler.go
+++ b/controllers/azurestackhcivirtualmachine_reconciler.go
@@ -230,15 +230,16 @@ func (s *azureStackHCIVirtualMachineService) createVirtualMachine(nicName string
 		s.vmScope.Info("VM type is:", "vmType", vmType)
 
 		vmSpec = &virtualmachines.Spec{
-			Name:       s.vmScope.Name(),
-			NICName:    nicName,
-			SSHKeyData: decodedKeys,
-			Size:       s.vmScope.AzureStackHCIVirtualMachine.Spec.VMSize,
-			OSDisk:     s.vmScope.AzureStackHCIVirtualMachine.Spec.OSDisk,
-			Image:      s.vmScope.AzureStackHCIVirtualMachine.Spec.Image,
-			CustomData: *s.vmScope.AzureStackHCIVirtualMachine.Spec.BootstrapData,
-			Zone:       vmZone,
-			VMType:     vmType,
+			Name:             s.vmScope.Name(),
+			NICName:          nicName,
+			SSHKeyData:       decodedKeys,
+			Size:             s.vmScope.AzureStackHCIVirtualMachine.Spec.VMSize,
+			OSDisk:           s.vmScope.AzureStackHCIVirtualMachine.Spec.OSDisk,
+			Image:            s.vmScope.AzureStackHCIVirtualMachine.Spec.Image,
+			CustomData:       *s.vmScope.AzureStackHCIVirtualMachine.Spec.BootstrapData,
+			Zone:             vmZone,
+			VMType:           vmType,
+			StorageContainer: s.vmScope.StorageContainer(),
 		}
 
 		err = s.virtualMachinesSvc.Reconcile(s.vmScope.Context, vmSpec)


### PR DESCRIPTION
Support for passing in a storage container name for the CAPH VMs (k8s and lb) to use. The storage container name will be passed to MOC SDK when we call to create a virtual machine, which should ensure that the VM is created on the requested MOC storage container. If no storage container is specified then MOC will choose a default container (the underlying default in MOC seems to be the default "MocStorageContainer" container).