### PR TITLE
Go Version 1.20 Bump

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - task: GoTool@0
         inputs:
-          version: "1.19.9"
+          version: "1.20.13"
         displayName: "Install Go"
 
       - script: |-

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL:=/usr/bin/env bash
 # Go version
 GO_VERSION := $(shell go env GOVERSION | sed "s/[^[:digit:].-]//g")
 ifeq ($(GO_VERSION),)
-GO_VERSION := 1.19.9
+GO_VERSION := 1.20.13
 endif
 
 # Use GOPROXY environment variable if set

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -26,7 +26,7 @@ steps:
       containerRegistry: mocimages-connection
   - task: GoTool@0
     inputs:
-      version: "1.19.9"
+      version: "1.20.13"
 
   - script: |
       git config --global url.ssh://git@github.com/.insteadOf https://github.com/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/cluster-api-provider-azurestackhci
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0


### PR DESCRIPTION
This is to prepare for the CAPI 1.5 bump, we need to have Go 1.20 to be able to run it