### PR TITLE
switch logger to klog which is same as k8s system components

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -30,11 +30,11 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // ClusterScopeParams defines the input parameters used to create a new Scope.
@@ -58,7 +58,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 	}
 
 	if params.Logger == nil {
-		log := zap.New(zap.UseDevMode(true))
+		log := klogr.New()
 		params.Logger = &log
 	}
 

--- a/cloud/scope/loadbalancer.go
+++ b/cloud/scope/loadbalancer.go
@@ -24,12 +24,12 @@ import (
 	infrav1 "github.com/microsoft/cluster-api-provider-azurestackhci/api/v1beta1"
 	"github.com/microsoft/moc/pkg/diagnostics"
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2/klogr"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // LoadBalancerScopeParams defines the input parameters used to create a new LoadBalancerScope.
@@ -53,7 +53,7 @@ func NewLoadBalancerScope(params LoadBalancerScopeParams) (*LoadBalancerScope, e
 	}
 
 	if params.Logger == nil {
-		log := zap.New(zap.UseDevMode(true))
+		log := klogr.New()
 		params.Logger = &log
 	}
 

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/klogr"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
@@ -34,7 +35,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
@@ -68,7 +68,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 	}
 
 	if params.Logger == nil {
-		log := zap.New(zap.UseDevMode(true))
+		log := klogr.New()
 		params.Logger = &log
 	}
 

--- a/cloud/scope/virtualmachine.go
+++ b/cloud/scope/virtualmachine.go
@@ -28,13 +28,13 @@ import (
 	"github.com/microsoft/moc/pkg/auth"
 	"github.com/microsoft/moc/pkg/diagnostics"
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2/klogr"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // MachineScopeParams defines the input parameters used to create a new VirtualMachineScope.
@@ -57,7 +57,7 @@ func NewVirtualMachineScope(params VirtualMachineScopeParams) (*VirtualMachineSc
 	}
 
 	if params.Logger == nil {
-		log := zap.New(zap.UseDevMode(true))
+		log := klogr.New()
 		params.Logger = &log
 	}
 

--- a/cloud/telemetry/logutils.go
+++ b/cloud/telemetry/logutils.go
@@ -75,12 +75,7 @@ func WriteMocOperationLog(logger logr.Logger, operation Operation, crResourceNam
 		Message:        message,
 	}
 
-	jsonData, serializeError := json.Marshal(oplog)
-	if serializeError != nil {
-		logger.Error(serializeError, "Unable to serialize operation log object.", "resourceName", crResourceName)
-	} else {
-		logger.Info(string(jsonData))
-	}
+	logger.Info("Record Moc Operation", "telemetry", oplog)
 }
 
 // RecordHybridAKSCRDChange need to be called when CRD changed.
@@ -103,17 +98,7 @@ func RecordHybridAKSCRDChange(logger logr.Logger, parentResource string, resourc
 		Message:        errMessage,
 	}
 
-	jsonData, serializeError := json.Marshal(oplog)
-	if serializeError != nil {
-		logger.Error(serializeError, "Unable to serialize operation log object",
-			"timestamp", time.Now().Format(time.RFC3339),
-			"parent_resource", parentResource,
-			"resource", resource,
-			"filter_keyword", "RESOURCE_ACTION",
-			"action", action)
-	} else {
-		logger.Info(string(jsonData))
-	}
+	logger.Info("Record HybridAKS CRD Change", "telemetry", oplog)
 }
 
 func GenerateMocResourceName(nameSegments ...string) string {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,13 +35,13 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	cgrecord "k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/microsoft/cluster-api-provider-azurestackhci/controllers"
 )
@@ -165,7 +165,7 @@ func main() {
 		}()
 	}
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(klogr.New())
 
 	// Machine and cluster operations can create enough events to trigger the event recorder spam filter
 	// Setting the burst size higher ensures all events will be recorded and submitted to the API

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/onsi/gomega/gexec"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/golang/mock/gomock"
 )
@@ -40,7 +40,10 @@ func TestClusterApiProviderAzureStackHCIControllerSuite(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	klog.InitFlags(nil)
+	klog.SetOutput(GinkgoWriter)
+	ctrl.SetLogger(klog.Background())
+	logf.SetLogger(klog.Background())
 
 	// Download the Machine CRD
 	resp, err := http.Get("https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/config/crd/bases/cluster.x-k8s.io_machines.yaml")

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
@@ -80,7 +79,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1181,7 +1181,6 @@ github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -1277,7 +1276,6 @@ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v1.2.4 h1:QHVo+6stLbfJmYGkQ7uGHUCu5hnAFAj6mDe6Ea0SeOo=
-github.com/go-logr/zapr v1.2.4/go.mod h1:FyHWQIzQORZ0QVE1BtVHv3cKtNLuXsbNLtpuhNapBOA=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonreference v0.20.1 h1:FBLnyygC4/IZZr893oiomc9XaghoveYTrLC1F86HID8=
@@ -1729,7 +1727,6 @@ go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTV
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
-go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -35,9 +35,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2/klogr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
@@ -59,7 +59,7 @@ func GetAuthorizerFromKubernetesCluster(ctx context.Context, cloudFqdn string) (
 	}
 	config.Timeout = 10 * time.Second
 
-	logger := zap.New(zap.UseDevMode(true))
+	logger := klogr.New()
 	c, err := client.New(config, client.Options{Scheme: Scheme})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a client")


### PR DESCRIPTION
## Description:

### Changes
switch logging library from zap to klog(same as k8s system components and capi. See: https://kubernetes.io/docs/concepts/cluster-administration/system-logs).

Using a consistent logging library across our entire system can simplify troubleshooting and parser/filter of logs.

Zap format:
   ` <ISO 8601 timestamp> <log  type>  <log names>  <message> { “<key1>”: “<values1>”, { “<key2>”: “<values2>”, ...}`

Klog format:
    `<log type><klog timestamp> <log level> <log source>]> <log names> “msg”=”<message>” “<key1>”=”<value1>” “<key2>”=”<value2>” ...`



### Local test result:
#### Before:
**2024-01-31T21:44:20Z**	INFO	**controllers.AzureStackHCIMachine**	Reconciling AzureStackHCIMachine	{"azureStackHCIMachine": "default/justisun-tcl-2e105d9f-nodepool1-6797f64bd8-hz6wg", "reconcileID": "e6c70c30-1811-43e2-a302-6cf0b535372b", "operationId": "9229ecd1-0029-452f-85e4-6a482aa15374*2E280647B825D1C3F81F7550E2C1328DF7EE767E8DCE940E4783D7BF6BEB300C", "correlationId": "1bdfb35d-982f-4572-a9ab-dc0138bd827c", "machine": "justisun-tcl-2e105d9f-nodepool1-md-6cb66959bbxbh56g-j5hx2", "cluster": "justisun-tcl-2e105d9f", "azureStackHCICluster": "justisun-tcl-2e105d9f"}

#### After:
**I0319 08:52:24.788606**       1 **azurestackhcimachine_controller.go:195]** **controllers/AzureStackHCIMachine** "msg"="Reconciling AzureStackHCIMachine" "azureStackHCICluster"="peidlu-test-37a403e5" "azureStackHCIMachine"={"Namespace":"default","Name":"peidlu-test-37a403e5-control-plane-6qkw8"} "cluster"="peidlu-test-37a403e5" "correlationId"="904d6ee1-4607-4f17-9582-aa2f194e72c9" "machine"="peidlu-test-37a403e5-control-plane-rkc65" "operationId"="b486b04c-d2c4-40b0-8507-3a0bad424fb7*DBD477D6B9C29D03853E52C75CAED283A9C628B50C90809346BFB6FDB5102B6F" "reconcileID"="a45aef0d-e33f-4b10-8f13-f66d273eac63"

