### PR TITLE
Add default ratelimiter

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/microsoft/cluster-api-provider-azurestackhci/controllers"
+	"k8s.io/client-go/util/workqueue"
 )
 
 var (
@@ -196,7 +197,10 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("AzureStackHCIMachine"),
 		Recorder: mgr.GetEventRecorderFor("azurestackhcimachine-reconciler"),
-	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: azureStackHCIMachineConcurrency}); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: azureStackHCIMachineConcurrency,
+		RateLimiter:             workqueue.DefaultControllerRateLimiter(),
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AzureStackHCIMachine")
 		os.Exit(1)
 	}
@@ -204,7 +208,10 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("AzureStackHCICluster"),
 		Recorder: mgr.GetEventRecorderFor("azurestackhcicluster-reconciler"),
-	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: azureStackHCIClusterConcurrency}); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: azureStackHCIClusterConcurrency,
+		RateLimiter:             workqueue.DefaultControllerRateLimiter(),
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AzureStackHCICluster")
 		os.Exit(1)
 	}
@@ -212,7 +219,10 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("AzureStackHCILoadBalancer"),
 		Recorder: mgr.GetEventRecorderFor("azurestackhciloadbalancer-reconciler"),
-	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: azureStackHCIloadBalancerConcurrency}); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: azureStackHCIloadBalancerConcurrency,
+		RateLimiter:             workqueue.DefaultControllerRateLimiter(),
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AzureStackHCILoadBalancer")
 		os.Exit(1)
 	}
@@ -221,7 +231,10 @@ func main() {
 		Log:      ctrl.Log.WithName("controllers").WithName("AzureStackHCIVirtualMachine"),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("azurestackhcivirtualmachine-reconciler"),
-	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: azureStackHCIVirtualMachineConcurrency}); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: azureStackHCIVirtualMachineConcurrency,
+		RateLimiter:             workqueue.DefaultControllerRateLimiter(),
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AzureStackHCIVirtualMachine")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Add default rateLimiter in each controller in case of constant error hits.

Especially when the backend hci infra has not enough resources, the virtualMachine controller should not always retry create vm but with some ExponentialFailure and max delay time. 