### PR TITLE
pretify moc version message

### DIFF
--- a/cloud/services/versions/versions.go
+++ b/cloud/services/versions/versions.go
@@ -32,7 +32,7 @@ type VersionPair struct {
 func (s *Service) Get(ctx context.Context) (*VersionPair, error) {
 	version, mocversion, err := s.Client.GetVersion(ctx)
 	if err != nil {
-		s.Scope.GetLogger().Error(err, "Unable to get moc deployment id")
+		s.Scope.GetLogger().Error(err, "Unable to get moc version")
 		return nil, err
 	}
 	return &VersionPair{

--- a/cloud/telemetry/logutils.go
+++ b/cloud/telemetry/logutils.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -130,12 +129,8 @@ func WriteMocInfoLog(ctx context.Context, scope scope.ScopeInterface) {
 		WssdCloudAgentVersion: wssdCloudAgentVersion,
 		MocVersion:            mocVersion,
 	}
-	jsonData, err := json.Marshal(infoLog)
-	if err != nil {
-		logger.Error(err, "Unable to serialize moc info log object.")
-	} else {
-		logger.Info(string(jsonData))
-	}
+
+	logger.Info("Record Moc Info", "mocInfo", infoLog)
 }
 
 func getVersionsService(scope scope.ScopeInterface) *versions.Service {


### PR DESCRIPTION
##Local test result:
###before:
I0409 03:18:48.151344       1 logutils.go:137] controllers/AzureStackHCICluster `"msg"="{\"wssd_cloud_agent_version\":\"v0.14.0\",\"moc_version\":\"v0.13.1\"}"` "azureStackHCICluster"={"Namespace":"default","Name":"575012192e3112b4f47b9ad41153455f4826460481c5f"} "cluster"="575012192e3112b4f47b9ad41153455f4826460481c5f" "correlationId"="" "operationId"="" "reconcileID"="3dfb3faf-ad59-409b-b810-6527326ebb84"

###after
I0409 03:29:04.249564       1 logutils.go:133] controllers/AzureStackHCICluster "msg"="Record Moc Info" "azureStackHCICluster"={"Namespace":"default","Name":"575012192e3112b4f47b9ad41153455f4826460481c5f"} "cluster"="575012192e3112b4f47b9ad41153455f4826460481c5f" "correlationId"="" `"mocInfo"={"wssd_cloud_agent_version":"v0.14.0","moc_version":"v0.13.1"}` "operationId"="" "reconcileID"="aac5166c-fe88-493b-af9e-f238f9f6693f"

