### PR TITLE
wait for volume attachments to be detached before deleting a vm

### DIFF
--- a/cloud/scope/virtualmachine.go
+++ b/cloud/scope/virtualmachine.go
@@ -139,6 +139,10 @@ func (m *VirtualMachineScope) ClusterName() string {
 	return m.AzureStackHCIVirtualMachine.Spec.ClusterName
 }
 
+func (m *VirtualMachineScope) Client() client.Client {
+	return m.client
+}
+
 // Location returns the AzureStackHCIVirtualMachine location.
 func (m *VirtualMachineScope) Location() string {
 	return m.AzureStackHCIVirtualMachine.Spec.Location

--- a/controllers/azurestackhcivirtualmachine_reconciler.go
+++ b/controllers/azurestackhcivirtualmachine_reconciler.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	waitVolumeAttachmentsInterval = time.Second * 10
+	waitVolumeAttachmentsInterval = time.Second * 2
 	waitVolumeAttachmentsTimeout  = time.Minute * 5
 )
 

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.3 // indirect
+	k8s.io/cluster-bootstrap v0.29.3 // indirect
 	k8s.io/component-base v0.29.3 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,17 +4,30 @@ import (
 	"context"
 	"crypto/rand"
 	"math/big"
+	"strings"
+	"time"
 
 	infrav1 "github.com/microsoft/cluster-api-provider-azurestackhci/api/v1beta1"
+	"github.com/pkg/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/pointer"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 const (
-	charSet = "abcdefghijklmnopqrstuvwxyz0123456789"
+	charSet       = "abcdefghijklmnopqrstuvwxyz0123456789"
+	diskCsiDriver = "disk.csi.akshci.com"
 )
 
 // GetAzureStackHCIMachinesInCluster gets a cluster's AzureStackHCIMachines resources.
@@ -35,6 +48,70 @@ func GetAzureStackHCIMachinesInCluster(ctx context.Context, controllerClient cli
 	}
 
 	return machines, nil
+}
+
+// Create a target cluster config based on the secret in the management cluster
+func NewTargetClusterConfig(ctx context.Context, controllerClient client.Reader, clusterKey client.ObjectKey) (*rest.Config, error) {
+	kubeconfig, err := kubeconfig.FromSecret(ctx, controllerClient, clusterKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for cluster %s:%s", clusterKey.Namespace, clusterKey.Name)
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create client configuration for cluster %s:%s", clusterKey.Namespace, clusterKey.Name)
+	}
+
+	return restConfig, nil
+}
+
+func NewTargetClusterClient(ctx context.Context, controllerClient client.Client, clusterKey client.ObjectKey) (*kubernetes.Clientset, error) {
+	restConfig, err := NewTargetClusterConfig(ctx, controllerClient, clusterKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create client configuration for cluster %s:%s", clusterKey.Namespace, clusterKey.Name)
+	}
+
+	// sets the timeout, otherwise this will default to 0 (i.e. no timeout)
+	restConfig.Timeout = 10 * time.Second
+
+	targetClusterClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to connect to the cluster %s:%s", clusterKey.Namespace, clusterKey.Name)
+	}
+
+	return targetClusterClient, err
+}
+
+// GetNodeName returns the Node Name from the resource's owning CAPI machine object.
+func GetNodeName(ctx context.Context, client client.Client, obj metav1.ObjectMeta) (string, error) {
+	machine, err := capiutil.GetOwnerMachine(ctx, client, obj)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get owner machine for %s.%s", obj.Namespace, obj.Name)
+	}
+	if machine == nil {
+		return "", errors.Errorf("resource %s.%s has no owning machine", obj.Namespace, obj.Name)
+	}
+	if machine.Status.NodeRef == nil {
+		return "", errors.Errorf("machine %s.%s has no node ref", machine.Namespace, machine.Name)
+	}
+	return machine.Status.NodeRef.Name, nil
+}
+
+func ListVolumeAttachmentOnNode(ctx context.Context, client *kubernetes.Clientset, clusterKey client.ObjectKey, nodeName string) ([]string, error) {
+	volumeAttachmentList, err := client.StorageV1().VolumeAttachments().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list VolumeAttachments for Cluster %s:%s", clusterKey.Namespace, clusterKey.Name)
+	}
+
+	res := []string{}
+	if volumeAttachmentList != nil && len(volumeAttachmentList.Items) > 0 {
+		for _, va := range volumeAttachmentList.Items {
+			if va.Spec.Attacher == diskCsiDriver && strings.EqualFold(va.Spec.NodeName, nodeName) {
+				res = append(res, pointer.StringDeref(va.Spec.Source.PersistentVolumeName, ""))
+			}
+		}
+	}
+	return res, nil
 }
 
 // RandomAlphaNumericString returns a random alphanumeric string.


### PR DESCRIPTION
This is to fix a bug that during workload cluster upgrade, it takes long time to wait for the PV to attach to the new node, we may see multiple errors like this:
 
I0404 11:45:49.477443       1 event.go:307] "Event occurred" object="default/sample-dddf7bd5-wglbx" fieldPath="" kind="Pod" apiVersion="v1" type="Warning" reason="FailedAttachVolume" message="Multi-Attach error for volume \"pvc-d0cec9c7-7d3a-4961-ab35-7bda48cbe5ee\" Volume is already used by pod(s) sample-dddf7bd5-7rh7q"

In this PR, we intentionally wait for the PV to detach from the old node before the vm is deleted to avoid the above error.