### PR TITLE
Add PathNotFound error code

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -36,6 +36,8 @@ const (
 	OutOfCapacityReason = "OutOfCapacity"
 	// OutOfNodeCapacityReason used when the AzureStackHCI node is out of capacity.
 	OutOfNodeCapacityReason = "OutOfNodeCapacity"
+	// PathNotFoundReason used when the AzureStackHCI GalleryImage is not found.
+	PathNotFoundReason = "PathNotFound"
 )
 
 // Conditions and condition Reasons for the AzureStackHCICluster object

--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -210,6 +210,8 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.OutOfCapacityReason, clusterv1.ConditionSeverityError, err.Error())
 			case mocerrors.OutOfNodeCapacity.Error():
 				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.OutOfNodeCapacityReason, clusterv1.ConditionSeverityWarning, err.Error())
+			case mocerrors.PathNotFound.Error():
+				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.PathNotFoundReason, clusterv1.ConditionSeverityWarning, err.Error())
 			default:
 				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.VMProvisionFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			}


### PR DESCRIPTION
Handle the error when the underlying GalleryImage is not found or corrupted instead of returning VMProvisionedFailed.