### PR TITLE
Add Generic Not Found case

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -38,6 +38,8 @@ const (
 	OutOfNodeCapacityReason = "OutOfNodeCapacity"
 	// PathNotFoundReason used when the AzureStackHCI GalleryImage is not found.
 	PathNotFoundReason = "PathNotFound"
+	// NotFoundReason used as a generic error reason when a resource is not found.
+	NotFoundReason = "PathNotFound"
 )
 
 // Conditions and condition Reasons for the AzureStackHCICluster object

--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -39,7 +39,7 @@ const (
 	// PathNotFoundReason used when the AzureStackHCI GalleryImage is not found.
 	PathNotFoundReason = "PathNotFound"
 	// NotFoundReason used as a generic error reason when a resource is not found.
-	NotFoundReason = "PathNotFound"
+	NotFoundReason = "NotFound"
 )
 
 // Conditions and condition Reasons for the AzureStackHCICluster object

--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -210,11 +210,11 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 			case mocerrors.OutOfCapacity.Error():
 				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.OutOfCapacityReason, clusterv1.ConditionSeverityError, err.Error())
 			case mocerrors.OutOfNodeCapacity.Error():
-				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.OutOfNodeCapacityReason, clusterv1.ConditionSeverityWarning, err.Error())
-			// Internally, NotFound is a legacy error and returns the error string instead.
-			case mocerrors.NotFound.Error():
+				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.OutOfNodeCapacityReason, clusterv1.ConditionSeverityWarning, err.Error())			
+			case mocerrors.NotFound.Error(): // "NotFound"
 				fallthrough
-			case moccodes.NotFound.String():
+			// Internally, NotFound is a legacy error and returns the error string instead.
+			case moccodes.NotFound.String(): // "Not Found"
 				if mocerrors.IsPathNotFound(err) {
 					conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.PathNotFoundReason, clusterv1.ConditionSeverityError, err.Error())
 				} else {					

--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -19,7 +19,6 @@ package controllers
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/microsoft/cluster-api-provider-azurestackhci/cloud/scope"
@@ -205,11 +204,6 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 		virtualMachineScope.Info("No VM found, creating VM", "Name", virtualMachineScope.Name())
 		vm, err = ams.Create()
 		if err != nil {
-			virtualMachineScope.Info("Switch statement value", mocerrors.GetErrorCode(err))
-			virtualMachineScope.Info("NotFound", mocerrors.NotFound.Error())
-			virtualMachineScope.Info("PathNotFound", mocerrors.PathNotFound.Error())
-			virtualMachineScope.Info("bool", strconv.FormatBool(mocerrors.IsPathNotFound(err)))
-			virtualMachineScope.Info("comp", strconv.FormatBool(mocerrors.GetErrorCode(err) == mocerrors.NotFound.Error()))
 			switch mocerrors.GetErrorCode(err) {
 			case mocerrors.OutOfMemory.Error():
 				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.OutOfMemoryReason, clusterv1.ConditionSeverityError, err.Error())

--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -212,6 +212,8 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 			case mocerrors.OutOfNodeCapacity.Error():
 				conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.OutOfNodeCapacityReason, clusterv1.ConditionSeverityWarning, err.Error())
 			// Internally, NotFound is a legacy error and returns the error string instead.
+			case mocerrors.NotFound.Error():
+				fallthrough
 			case moccodes.NotFound.String():
 				if mocerrors.IsPathNotFound(err) {
 					conditions.MarkFalse(virtualMachineScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition, infrav1.PathNotFoundReason, clusterv1.ConditionSeverityError, err.Error())


### PR DESCRIPTION
Not Found error is considered a Legacy error code and does not get picked up by GetErrorCode()
GetErrorCode() returns NotFound error for PathNotFound, BlobNotFound, FileNotFound and generic NotFound

Also adding a generic error message to catch generic NotFounds.