### PR TITLE
Update Go version to 1.24.13

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - task: GoTool@0
         inputs:
-          version: "1.23.0"
+          version: "1.24.13"
         displayName: "Install Go"
 
       - script: |-

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL:=/usr/bin/env bash
 # Go version
 GO_VERSION := $(shell go env GOVERSION | sed "s/[^[:digit:].-]//g")
 ifeq ($(GO_VERSION),)
-GO_VERSION := 1.23.0
+GO_VERSION := 1.24.13
 endif
 
 # Use GOPROXY environment variable if set

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/cluster-api-provider-azurestackhci
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0


### PR DESCRIPTION
## Summary

Updates Go version to 1.24.13 (latest 1.24 patch) across all configuration files.

## Changes

- **go.mod**: Bump `go` directive from 1.24.0 to 1.24.13
- **Makefile**: Update fallback `GO_VERSION` from 1.23.0 to 1.24.13
- **.pipelines/build.yaml**: Update GoTool version from 1.23.0 to 1.24.13

## Motivation

Go 1.24.13 includes critical security fixes for `cmd/cgo` and `crypto/tls`. The Makefile and pipeline config were also stale at 1.23.0, which is older than the minimum version required by go.mod.