### PR TITLE
fix: remove sticky error state guard in Machine controller reconcileNormal

### DIFF
--- a/controllers/azurestackhcimachine_controller.go
+++ b/controllers/azurestackhcimachine_controller.go
@@ -193,15 +193,11 @@ func (r *AzureStackHCIMachineReconciler) Reconcile(ctx context.Context, req ctrl
 
 func (r *AzureStackHCIMachineReconciler) reconcileNormal(machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
 	machineScope.Info("Reconciling AzureStackHCIMachine")
-	// If the AzureStackHCIMachine is in an error state, return early.
-	// In v1beta2, we check conditions for error states
-	vmRunningCondition := conditions.Get(machineScope.AzureStackHCIMachine, infrav1.VMRunningCondition)
-	if vmRunningCondition != nil && vmRunningCondition.Status == metav1.ConditionFalse &&
-		(vmRunningCondition.Reason != "") {
-		machineScope.Info("Error state detected, skipping reconciliation")
-		r.Recorder.Eventf(machineScope.AzureStackHCIMachine, corev1.EventTypeWarning, "ErrorStateAzureStackHCIMachine", "AzureStackHCIMachine is in an error state")
-		return reconcile.Result{}, nil
-	}
+	// NOTE: Do not gate reconciliation on stale Machine conditions (e.g. VMRunningCondition=False).
+	// The VM controller owns VM state and can recover asynchronously after transient failures
+	// (e.g. MOC I/O errors). The Machine controller must always re-fetch the VM CR to get
+	// current status, otherwise a stale error condition permanently blocks reconciliation
+	// even after the VM has been successfully created.
 
 	// If the AzureMachine doesn't have our finalizer, add it.
 	controllerutil.AddFinalizer(machineScope.AzureStackHCIMachine, infrav1.MachineFinalizer)


### PR DESCRIPTION
## Problem

The AzureStackHCIMachine controller's reconcileNormal() has an early-return guard that checks VMRunningCondition=False and skips reconciliation entirely. This causes a **permanent stuck state** when VM creation fails transiently and then succeeds on retry, because the stale condition on the Machine CR is never re-evaluated.

### Observed failure (pipeline build 161302546)

1. **05:57:31** - First VM creation attempt fails at MOC layer (Windows I/O error writing .tag file)
2. **06:01:27** - Second VM creation attempt **succeeds** (MOC confirms error_code: 0, SuccessfulCreateVM event emitted)
3. **06:01:27+** - Machine controller reconciles, sees VMRunningCondition=False (stale from step 1), returns immediately without re-fetching VM CR
4. **06:51:34** - MachineHealthCheck deletes the perfectly healthy VM after 50 minutes of no progress

The Machine never reaches Ready despite the VM being successfully created and running.

### Root Cause

Lines 196-204 of azurestackhcimachine_controller.go (before this fix):

`go
vmRunningCondition := conditions.Get(machineScope.AzureStackHCIMachine, infrav1.VMRunningCondition)
if vmRunningCondition != nil && vmRunningCondition.Status == corev1.ConditionFalse {
    return ctrl.Result{}, errors.Errorf(...)
}
``n
This guard returns an error **without re-fetching the VM CR**, so it uses stale status. The VM controller can recover the VM asynchronously, but the Machine controller never sees the recovery.

## Fix

Remove the sticky error guard entirely. The rest of reconcileNormal() already handles all VM states correctly via a switch block on VMState (Succeeded, Updating, Failed, etc.). The conditions should propagate state, not gate reconciliation.

## Testing

- Existing tests pass (all tests are for reconcileVirtualMachineDelete, not the modified path)
- Build verified: go build ./controllers/... succeeds
- The removed guard was unreachable in many code paths anyway (VM controller in v1beta2 never sets FailureReason/FailureMessage that would trigger the condition)

## Risk Assessment

**Low risk.** The guard was overly conservative - it prevented recovery from transient failures. Removing it allows the natural reconciliation loop to proceed, which already has proper state handling via the VMState switch block. There is no risk of hot-looping because the controller always returns RequeueAfter or waits for watch events.

---

## 🔁 Update 2026-06-23 — Recurrence on 22H2 E2E Upgrade (build 169193975)

This exact defect **recurred** in the 22H2 E2E Upgrade pipeline (ADO build **169193975**), confirming the bug is still live in `master` because this fix has not yet merged. Captured on a held debug VM with full CR + controller-log evidence.

### Symptom
Workload cluster `workload-1c8b8b2f` control-plane upgrade hung indefinitely: a KCP-owned control-plane `Machine` (`workload-1c8b8b2f-control-plane-s2v6k`) stuck in `Provisioning`, so KCP could not roll the 3rd CP. The underlying VM, node, and etcd member were all **healthy** the whole time.

### Decisive evidence — the two CRs disagree
The `AzureStackHCIVirtualMachine` (VM layer) recovered and reports success; the `AzureStackHCIMachine` (Machine layer) is frozen on the stale failure and was never re-reconciled:

| CR | `VMRunning` condition | `status` | `lastTransitionTime` | other |
|----|----|----|----|----|
| `AzureStackHCIVirtualMachine/…-s2v6k` | `True` / `Succeeded` | — | **19:58:52Z** (T2) | `ready: true`, `vmState: Succeeded` |
| `AzureStackHCIMachine/…-s2v6k` | `False` / `VMProvisionFailed` | — | **19:54:51Z** (T1) | `ready: false`, `resourceVersion` frozen at `50673`, `spec.providerID` already set |

- **T1 19:54:51Z** — transient MOC host I/O error set `VMRunning=False/VMProvisionFailed`:
  `failed to generate tag file "E:\…\E6DA6616-8EC4-48E0-BE93-58CE6ACE3CFB.tag" after 4 attempts (transient ERROR_INVALID_USER_BUFFER)`
- **T2 19:58:52Z** (~4 min later) — VM retry **succeeded**: `AzureStackHCIVirtualMachine` → `VMRunning=True/Succeeded`, `ready=true`, `vmState=Succeeded`.
- The `AzureStackHCIMachine` **never moved** after T1 (`resourceVersion` 50673 unchanged through 00:01Z).

### Confirmed mechanism (the latch)
caph logs from the wedged window (23:48–00:01Z) show, every reconcile cycle:
- `azurestackhcivirtualmachine_controller.go:176` `"Machine VM is running"` + `controller.go:489` `"Reconcile successful"` for `s2v6k` — VM layer healthy.
- `azurestackhcimachine_controller.go:201` `"Error state detected, skipping reconciliation"` for `s2v6k` — the Machine controller returns at the guard **before** reaching `reconcileVirtualMachineNormal()`, so it never re-reads the now-`Succeeded` VM and never clears its own stale `VMRunning=False`.

The controller **does** watch `AzureStackHCIVirtualMachine` (owner-enqueue), so the T2 success enqueued a Machine reconcile — but the guard at lines 196–204 ate the event. This is precisely the early-return guard removed by this PR.

### Asymmetry that confirms the root cause
The sibling `AzureStackHCIVirtualMachine` controller guards on the **terminal** `Status.FailureReason/FailureMessage` (never set in v1beta2) — so it never latches and correctly recovered. The `AzureStackHCIMachine` guard was repointed (in the CAPI 1.11 migration, commit `0d599a5`) to the **transient** `VMRunning` condition mirror, which IS set on any provisioning hiccup → permanent latch. Removing it restores symmetry and pre-1.11 behavior.

### Downstream impact
Because `AzureStackHCIMachine.status.ready` stays `false`, the CAPI `Machine` stays `InfrastructureReady=False` → stuck `Provisioning`; KCP cannot remediate the CP machine (etcd-quorum guard), so the whole control-plane upgrade hangs until manual intervention.

### Manual mitigation used to unblock (non-destructive)
`spec.providerID` is already set and the node is a live etcd member, so **do not delete the Machine**. Clearing the stale condition lets caph reconcile forward:
```
kubectl patch azurestackhcimachine <name> -n default --subresource=status --type=json \
  -p '[{"op":"replace","path":"/status/conditions/0/status","value":"True"},
       {"op":"replace","path":"/status/conditions/0/reason","value":"VMRunning"},
       {"op":"replace","path":"/status/ready","value":true}]'
```

### Two independent repros now on record
- build **161302546** (original): MHC deleted the healthy VM after 50 min.
- build **169193975** (this update): CP upgrade hang; full CR + log capture above.

This second occurrence on a customer-facing 22H2 upgrade path raises the priority of merging this guard removal.
