### PR TITLE
fix: handle empty Reason in v1beta1-to-v1beta2 condition and OSDisk conversion

### DIFF
--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -159,6 +159,12 @@ func Convert_v1beta1_Condition_To_v1_Condition(in *corev1beta1.Condition, out *m
 	out.Status = metav1.ConditionStatus(in.Status)
 	out.LastTransitionTime = in.LastTransitionTime
 	out.Reason = in.Reason
+	// v1beta1 Reason is optional (json omitempty), but v1beta2 metav1.Condition
+	// requires Reason with minLength=1. Objects stored as v1beta1 may have empty
+	// Reason, which would fail CRD validation after upgrade to v1beta2 storage.
+	if out.Reason == "" {
+		out.Reason = string(in.Type)
+	}
 	out.Message = in.Message
 	// corev1beta1.Condition doesn't have ObservedGeneration field
 	return nil
@@ -171,11 +177,10 @@ func Convert_v1beta1_OSDisk_To_v1beta2_OSDisk(in *OSDisk, out *v1beta2.OSDisk, s
 	out.Source = in.Source
 	out.OSType = v1beta2.OSType(in.OSType)
 	out.DiskSizeGB = in.DiskSizeGB
-	// Convert value type to pointer - only set if non-empty
-	if in.ManagedDisk.StorageAccountType != "" {
-		out.ManagedDisk = &v1beta2.ManagedDisk{
-			StorageAccountType: in.ManagedDisk.StorageAccountType,
-		}
+	// Always create ManagedDisk pointer — v1beta2 CRD requires managedDisk
+	// to be present. Using empty StorageAccountType is safe as MOC handles defaults.
+	out.ManagedDisk = &v1beta2.ManagedDisk{
+		StorageAccountType: in.ManagedDisk.StorageAccountType,
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

After upgrading CAPI/CAPH from v1beta1 to v1beta2 storage, **all status patches fail with 422 Unprocessable Entity**:

```
conditions[0].reason: Invalid value "": conditions[0].reason in body should be at least 1 chars long
```

This blocks ALL machine provisioning after an upgrade — 9,407 occurrences observed in a single pipeline run.

### Root Cause

1. Objects created by old CAPH (v1beta1 API) store conditions where `Reason` is empty string
2. v1beta1 `Reason` field has `json:"reason,omitempty"` — empty string is **omitted** from stored JSON — valid
3. After CAPI/CAPH upgrade, v1beta2 CRD is registered with `reason: required, minLength: 1`
4. On read, API server converts v1beta1 to v1beta2: `out.Reason = in.Reason` copies empty string
5. v1beta2 JSON serializes `"reason": ""` (no omitempty) — fails CRD validation
6. Every status patch rejected — `provisioned` stays false forever — pipeline times out

### Evidence

| Machine | Created By | Status Patch |
|---------|-----------|--------------|
| pgdzn (new mgmt CP) | New CAPH (v1beta2) | Succeeds |
| control-plane-0 (old mgmt CP) | Old CAPH (v1beta1) | 422 (24x) |
| workload-control-plane-cv9gn | Old CAPH (v1beta1) | 422 (143x) |
| testnodepool-* (4 machines) | Old CAPH (v1beta1) | 422 (128x each) |

### Fix

**Condition conversion** (line 161): Default empty Reason to the condition Type during v1beta1 to v1beta2 conversion. This satisfies CRD validation while preserving semantic meaning.

**OSDisk conversion** (line 175): Always create ManagedDisk pointer since v1beta2 CRD requires it. Previously, empty StorageAccountType left ManagedDisk nil, causing `bastion.osDisk.managedDisk: Required value`.

### Testing

- [x] `go build ./...` passes
- [ ] Integration test with upgrade pipeline
