### PR TITLE
Bump Go to 1.25.9

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - task: GoTool@0
         inputs:
-          version: "1.25.0"
+          version: "1.25.9"
         displayName: "Install Go"
 
       - script: |-

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL:=/usr/bin/env bash
 # Go version
 GO_VERSION := $(shell go env GOVERSION | sed "s/[^[:digit:].-]//g")
 ifeq ($(GO_VERSION),)
-GO_VERSION := 1.25.0
+GO_VERSION := 1.25.9
 endif
 
 # Use GOPROXY environment variable if set

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -26,7 +26,7 @@ steps:
       containerRegistry: mocimages-connection
   - task: GoTool@0
     inputs:
-      version: "1.22.4"
+      version: "1.25.9"
 
   - script: |
       git config --global url.ssh://git@github.com/.insteadOf https://github.com/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/cluster-api-provider-azurestackhci
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0


### PR DESCRIPTION
## Summary
Bumps the Go version to **1.25.9** across the repository.

### Changes
- `go.mod` — `go` directive `1.25.0` → `1.25.9`
- `Makefile` — `GO_VERSION` fallback `1.25.0` → `1.25.9`
- `.pipelines/build.yaml` — `GoTool@0` install version `1.25.0` → `1.25.9`
- `azure-pipelines-release.yml` — `GoTool@0` install version `1.22.4` → `1.25.9` (was lagging)

No source code changes; this is a toolchain/version bump only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>