### PR TITLE
Classify MOC unreachable (gRPC Unavailable) with a deterministic reason

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -40,6 +40,11 @@ const (
 	PathNotFoundReason = "PathNotFound"
 	// NotFoundReason used as a generic error reason when a resource is not found.
 	NotFoundReason = "NotFound"
+	// MocUnreachableReason used when the MOC agent is unreachable, i.e. the gRPC call to MOC
+	// failed with codes.Unavailable (for example a DNS/transport dial failure to the MOC host).
+	// This is deterministic at the call-site because the failing call targets MOC, so downstream
+	// consumers can switch on the reason instead of pattern-matching the error message.
+	MocUnreachableReason = "MocUnreachable"
 )
 
 // Conditions and condition Reasons for the AzureStackHCICluster object

--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -40,11 +40,11 @@ const (
 	PathNotFoundReason = "PathNotFound"
 	// NotFoundReason used as a generic error reason when a resource is not found.
 	NotFoundReason = "NotFound"
-	// MocUnreachableReason used when the MOC agent is unreachable, i.e. the gRPC call to MOC
+	// MOCUnreachableReason used when the MOC agent is unreachable, i.e. the gRPC call to MOC
 	// failed with codes.Unavailable (for example a DNS/transport dial failure to the MOC host).
 	// This is deterministic at the call-site because the failing call targets MOC, so downstream
 	// consumers can switch on the reason instead of pattern-matching the error message.
-	MocUnreachableReason = "MocUnreachable"
+	MOCUnreachableReason = "MOCUnreachable"
 )
 
 // Conditions and condition Reasons for the AzureStackHCICluster object

--- a/api/v1beta2/conditions_consts.go
+++ b/api/v1beta2/conditions_consts.go
@@ -38,6 +38,11 @@ const (
 	PathNotFoundReason = "PathNotFound"
 	// NotFoundReason used as a generic error reason when a resource is not found.
 	NotFoundReason = "NotFound"
+	// MocUnreachableReason used when the MOC agent is unreachable, i.e. the gRPC call to MOC
+	// failed with codes.Unavailable (for example a DNS/transport dial failure to the MOC host).
+	// This is deterministic at the call-site because the failing call targets MOC, so downstream
+	// consumers can switch on the reason instead of pattern-matching the error message.
+	MocUnreachableReason = "MocUnreachable"
 )
 
 // Conditions and condition Reasons for the AzureStackHCICluster object

--- a/api/v1beta2/conditions_consts.go
+++ b/api/v1beta2/conditions_consts.go
@@ -38,11 +38,11 @@ const (
 	PathNotFoundReason = "PathNotFound"
 	// NotFoundReason used as a generic error reason when a resource is not found.
 	NotFoundReason = "NotFound"
-	// MocUnreachableReason used when the MOC agent is unreachable, i.e. the gRPC call to MOC
+	// MOCUnreachableReason used when the MOC agent is unreachable, i.e. the gRPC call to MOC
 	// failed with codes.Unavailable (for example a DNS/transport dial failure to the MOC host).
 	// This is deterministic at the call-site because the failing call targets MOC, so downstream
 	// consumers can switch on the reason instead of pattern-matching the error message.
-	MocUnreachableReason = "MocUnreachable"
+	MOCUnreachableReason = "MOCUnreachable"
 )
 
 // Conditions and condition Reasons for the AzureStackHCICluster object

--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -271,7 +271,7 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 				// error message.
 				reason := infrav1.VMProvisionFailedReason
 				if mocerrors.IsGRPCUnavailable(err) {
-					reason = infrav1.MocUnreachableReason
+					reason = infrav1.MOCUnreachableReason
 				}
 				conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
 					Type:    infrav1.VMRunningCondition,

--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -263,10 +263,20 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 					})
 				}
 			default:
+				// MOC unreachable (gRPC codes.Unavailable — e.g. a DNS/transport dial failure to
+				// the MOC agent) lands in this generic bucket because GetErrorCode does not inspect
+				// gRPC status codes. It is deterministic at this call-site (we are dialing MOC), so
+				// surface a typed reason here instead of leaving it as a generic provisioning
+				// failure that downstream consumers would otherwise have to pattern-match from the
+				// error message.
+				reason := infrav1.VMProvisionFailedReason
+				if mocerrors.IsGRPCUnavailable(err) {
+					reason = infrav1.MocUnreachableReason
+				}
 				conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
 					Type:    infrav1.VMRunningCondition,
 					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.VMProvisionFailedReason,
+					Reason:  reason,
 					Message: err.Error(),
 				})
 			}


### PR DESCRIPTION
## What this PR does / why we need it

When the MOC agent is unreachable, the gRPC call to MOC fails with `codes.Unavailable` — e.g. a DNS/transport dial failure:

```
rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp: lookup <azure-local-host>: i/o timeout"
```

During `AzureStackHCIVirtualMachine` VM-create, this was classified as the generic `VMProvisionFailedReason`, because `mocerrors.GetErrorCode` does not inspect gRPC status codes (it only matches MOC sentinel errors and otherwise returns the raw error string, which falls through to the `default` case).

As a result, downstream consumers (cloud-operator / AKS Edge Operator) had to **pattern-match the error message string** to recognize MOC unreachability — fragile, and not actually MOC-specific (any gRPC/DNS timeout has the same shape).

## What changed

- **`getOrCreate`'s `default` case** now checks `mocerrors.IsGRPCUnavailable(err)` (`github.com/microsoft/moc/pkg/errors`) directly, instead of a hand-rolled gRPC status check — matching the pattern already used by the `switch mocerrors.GetErrorCode(err) { case mocerrors.OutOfMemory.Error(): ... }` statements immediately above it in the same function (per review feedback from @Eshaan-Lumba).
- **`infrav1.MocUnreachableReason = "MocUnreachable"`** — new `VMRunningCondition` reason, set instead of `VMProvisionFailedReason` when the VM-create error is gRPC `Unavailable`.

This lets consumers switch on a **deterministic reason** instead of regexing the message.

> **Scope note:** an earlier revision of this PR also included a second, independent fix (preventing `AzureStackHCIMachineReconciler` from clobbering a detailed `VMRunningCondition` with a generic fallback message). That propagation gap is now fixed directly in cloud-operator (reads `VMRunningCondition` off `AzureStackHCIMachine` directly for the control-plane-readiness path), so it's been dropped from this PR to keep it narrowly scoped to the gRPC-Unavailable classification.

## Testing

- `go build ./...`, `go vet ./controllers/... ./cloud/...`, `gofmt` clean.
- `go test ./controllers/...` — full suite passes.
- Manually verified `mocerrors.IsGRPCUnavailable` correctly classifies both a raw and a double-wrapped (`pkg/errors.Wrapf`) gRPC `Unavailable` status, matching the real wrap chain produced by `reconcileNetworkInterface`/`createVirtualMachine` → `getOrCreate`.

## Context

Observed on Azure Local (AKS Arc) cluster create, correlationId
`ea0a92b1-a359-4b19-a101-0c54ceeae27e`: CAPH could not resolve the MOC host during NIC create; the
gRPC `Unavailable` surfaced as a generic timeout, and the failure was reported as a non-actionable
`TimeoutError` instead of MOC-unreachable. Internal tracking: AB#38532656, AB#38717753.

Follow-up: the same classification can be applied to other MOC call-sites (VNet/cluster, load
balancer) in subsequent PRs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
