### PR TITLE
Surface terminal VM provisioning failures on the CAPI contract Ready condition

### DIFF
--- a/controllers/azurestackhcivirtualmachine_controller.go
+++ b/controllers/azurestackhcivirtualmachine_controller.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -180,6 +181,13 @@ func (r *AzureStackHCIVirtualMachineReconciler) reconcileNormal(virtualMachineSc
 			Status: metav1.ConditionTrue,
 			Reason: string(infrav1.VMStateSucceeded),
 		})
+		// Also clear the CAPI contract "Ready" condition so a prior terminal failure
+		// (surfaced via setVMProvisionFailure) is reset once the VM comes up. See AB#38511842.
+		conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
+			Type:   clusterv1.ReadyCondition,
+			Status: metav1.ConditionTrue,
+			Reason: string(infrav1.VMStateSucceeded),
+		})
 	case infrav1.VMStateUpdating:
 		virtualMachineScope.Info("Machine VM is updating", "name", virtualMachineScope.Name())
 		conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
@@ -199,6 +207,29 @@ func (r *AzureStackHCIVirtualMachineReconciler) reconcileNormal(virtualMachineSc
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// setVMProvisionFailure records a terminal VM-provisioning failure on both the legacy
+// VMRunningCondition and the CAPI contract "Ready" condition. The AzureStackHCIMachine
+// controller copies every VM condition onto the AzureStackHCIMachine, and CAPI mirrors the
+// infra machine's contract "Ready" condition into Machine.InfrastructureReadyCondition,
+// carrying the real reason + message that cloud-operator surfaces as an actionable terminal
+// error. Without the "Ready" condition, CAPI falls back to a generic
+// "<Kind> status.initialization.provisioned is false" message and the real SKU/capacity
+// failure is dropped, so the operation stalls with an empty timeout. See AB#38511842.
+func setVMProvisionFailure(virtualMachineScope *scope.VirtualMachineScope, reason, message string) {
+	conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
+		Type:    infrav1.VMRunningCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
+	conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
+		Type:    clusterv1.ReadyCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	})
 }
 
 func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope *scope.VirtualMachineScope, ams *azureStackHCIVirtualMachineService) (*infrav1.VM, error) {
@@ -223,44 +254,19 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 		if err != nil {
 			switch mocerrors.GetErrorCode(err) {
 			case mocerrors.OutOfMemory.Error():
-				conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
-					Type:    infrav1.VMRunningCondition,
-					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.OutOfMemoryReason,
-					Message: err.Error(),
-				})
+				setVMProvisionFailure(virtualMachineScope, infrav1.OutOfMemoryReason, err.Error())
 			case mocerrors.OutOfCapacity.Error():
-				conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
-					Type:    infrav1.VMRunningCondition,
-					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.OutOfCapacityReason,
-					Message: err.Error(),
-				})
+				setVMProvisionFailure(virtualMachineScope, infrav1.OutOfCapacityReason, err.Error())
 			case mocerrors.OutOfNodeCapacity.Error():
-				conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
-					Type:    infrav1.VMRunningCondition,
-					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.OutOfNodeCapacityReason,
-					Message: err.Error(),
-				})
+				setVMProvisionFailure(virtualMachineScope, infrav1.OutOfNodeCapacityReason, err.Error())
 			case mocerrors.NotFound.Error(): // "NotFound"
 				fallthrough
 			// Internally, NotFound is a legacy error and returns the error string instead.
 			case moccodes.NotFound.String(): // "Not Found"
 				if mocerrors.IsPathNotFound(err) {
-					conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
-						Type:    infrav1.VMRunningCondition,
-						Status:  metav1.ConditionFalse,
-						Reason:  infrav1.PathNotFoundReason,
-						Message: err.Error(),
-					})
+					setVMProvisionFailure(virtualMachineScope, infrav1.PathNotFoundReason, err.Error())
 				} else {
-					conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
-						Type:    infrav1.VMRunningCondition,
-						Status:  metav1.ConditionFalse,
-						Reason:  infrav1.NotFoundReason,
-						Message: err.Error(),
-					})
+					setVMProvisionFailure(virtualMachineScope, infrav1.NotFoundReason, err.Error())
 				}
 			default:
 				// MOC unreachable (gRPC codes.Unavailable — e.g. a DNS/transport dial failure to
@@ -273,12 +279,7 @@ func (r *AzureStackHCIVirtualMachineReconciler) getOrCreate(virtualMachineScope 
 				if mocerrors.IsGRPCUnavailable(err) {
 					reason = infrav1.MOCUnreachableReason
 				}
-				conditions.Set(virtualMachineScope.AzureStackHCIVirtualMachine, metav1.Condition{
-					Type:    infrav1.VMRunningCondition,
-					Status:  metav1.ConditionFalse,
-					Reason:  reason,
-					Message: err.Error(),
-				})
+				setVMProvisionFailure(virtualMachineScope, reason, err.Error())
 			}
 
 			wrappedErr := errors.Wrapf(err, "failed to create AzureStackHCIVirtualMachine")

--- a/controllers/azurestackhcivirtualmachine_controller_test.go
+++ b/controllers/azurestackhcivirtualmachine_controller_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	infrav1 "github.com/microsoft/cluster-api-provider-azurestackhci/api/v1beta2"
+	"github.com/microsoft/cluster-api-provider-azurestackhci/cloud/scope"
+)
+
+// TestSetVMProvisionFailure verifies that a terminal VM-provisioning failure is recorded on
+// BOTH the legacy VMRunningCondition and the CAPI contract "Ready" condition. The "Ready"
+// condition is what CAPI mirrors into Machine.InfrastructureReadyCondition; without it the real
+// SKU/capacity error is dropped and the operation stalls with an empty timeout. See AB#38511842.
+func TestSetVMProvisionFailure(t *testing.T) {
+	g := NewWithT(t)
+
+	const message = "rpc error: code = Unknown desc = InvalidVMSku: vm size Standard_D4s_v3 is not available"
+	vmScope := &scope.VirtualMachineScope{
+		AzureStackHCIVirtualMachine: &infrav1.AzureStackHCIVirtualMachine{},
+	}
+
+	setVMProvisionFailure(vmScope, infrav1.OutOfCapacityReason, message)
+
+	// Legacy condition is still set (unchanged behavior).
+	vmRunning := conditions.Get(vmScope.AzureStackHCIVirtualMachine, infrav1.VMRunningCondition)
+	g.Expect(vmRunning).ToNot(BeNil())
+	g.Expect(vmRunning.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(vmRunning.Reason).To(Equal(infrav1.OutOfCapacityReason))
+	g.Expect(vmRunning.Message).To(Equal(message))
+
+	// New: the CAPI contract "Ready" condition carries the real reason + message so CAPI mirrors
+	// it into Machine.InfrastructureReadyCondition (instead of the generic provisioned fallback).
+	ready := conditions.Get(vmScope.AzureStackHCIVirtualMachine, clusterv1.ReadyCondition)
+	g.Expect(ready).ToNot(BeNil())
+	g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(ready.Reason).To(Equal(infrav1.OutOfCapacityReason))
+	g.Expect(ready.Message).To(Equal(message))
+}


### PR DESCRIPTION
## Summary

When a VM `Create()` fails terminally during a nodepool surge / rolling node replacement (capacity, `InvalidVMSku`, missing VHD path, etc.), CAPH classifies the error and goes terminal, but only records it on **`VMRunningCondition`**. CAPI v1.12.5 (`setInfrastructureReadyCondition`) mirrors the infra machine's **contract `"Ready"` condition** into `Machine.InfrastructureReadyCondition`. Since CAPH never set a `"Ready"` condition, CAPI fell back to the generic `"<Kind> status.initialization.provisioned is false"` message and the **real SKU/capacity error was dropped** — the upgrade/replacement stalled with an empty `"Detailed message: : Timed out"` and retried for days.

## Fix

Set the CAPI contract `"Ready"` condition (Type `"Ready"`) alongside `VMRunningCondition` for the terminal `Create()` failure cases (OutOfMemory, OutOfCapacity, OutOfNodeCapacity, PathNotFound, NotFound, VMProvisionFailed), carrying the **same reason + message**. The `AzureStackHCIMachine` controller already copies every VM condition onto the machine, so CAPI now mirrors the real reason/message into `InfrastructureReadyCondition`, which the existing cloud-operator pipe surfaces as an actionable terminal error. On `VMStateSucceeded` the `"Ready"` condition is set `True` so a prior failure is cleared.

No cloud-operator change required. Verified against CAPI v1.12.5 (`ReadyConditionType()` -> `"Ready"`, `NewMirrorConditionFromUnstructured` with generic fallback) and the existing VM-condition copy loop.

## Testing

- `go build ./controllers/...`, `go vet ./controllers/` -- clean.
- New unit test `TestSetVMProvisionFailure` asserts an `OutOfCapacity` failure sets `Ready=False` with the message on the `AzureStackHCIVirtualMachine`.

Fixes AB#38511842 (parent AB#38321574).
