### PR TITLE
fix: bump Go toolchain to 1.25.12 for GO-2026-4970

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - task: GoTool@0
         inputs:
-          version: "1.25.11"
+          version: "1.25.12"
         displayName: "Install Go"
 
       - script: |-

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL:=/usr/bin/env bash
 # Go version
 GO_VERSION := $(shell go env GOVERSION | sed "s/[^[:digit:].-]//g")
 ifeq ($(GO_VERSION),)
-GO_VERSION := 1.25.11
+GO_VERSION := 1.25.12
 endif
 
 # Use GOPROXY environment variable if set

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -26,7 +26,7 @@ steps:
       containerRegistry: mocimages-connection
   - task: GoTool@0
     inputs:
-      version: "1.25.11"
+      version: "1.25.12"
 
   - script: |
       git config --global url.ssh://git@github.com/.insteadOf https://github.com/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/cluster-api-provider-azurestackhci
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0


### PR DESCRIPTION
S360 flags the CAPH image for [GO-2026-4970](https://pkg.go.dev/vuln/GO-2026-4970) / CVE-2026-39822 — a Go stdlib bug where `os.Root` follows a symlink outside the root when the final path component is a symlink and the path ends in `/` (e.g. `root.Open("symlink/")`).

It's a toolchain vuln, not a dependency or app-code bug — the fix is just recompiling with a patched Go. CAPH is on the 1.25 line, fixed in `1.25.12`:

- `go.mod` / `Makefile` fallback: `1.25.11` -> `1.25.12`
- both `GoTool@0` pins (`azure-pipelines-release.yml`, `.pipelines/build.yaml`): `1.25.11` -> `1.25.12` — the release build is what produces the shipped `manager` binary the scanner re-scans

Staying on the same 1.25 minor line, so no language/behavior change. CAPH doesn't use `os.Root` in its own code (0 usages), so runtime exposure is nil — this is a compile-hygiene bump to clear the scanner.

Needs an image rebuild+republish (via the release pipeline) for the scanner to re-scan the recompiled binary.
