### PR TITLE
Bump Go to 1.26.6 to clear stdlib CVEs

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - task: GoTool@0
         inputs:
-          version: "1.26.5"
+          version: "1.26.6"
         displayName: "Install Go"
 
       - script: |-

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL:=/usr/bin/env bash
 # Go version
 GO_VERSION := $(shell go env GOVERSION | sed "s/[^[:digit:].-]//g")
 ifeq ($(GO_VERSION),)
-GO_VERSION := 1.26.5
+GO_VERSION := 1.26.6
 endif
 
 # Use GOPROXY environment variable if set

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -26,7 +26,7 @@ steps:
       containerRegistry: mocimages-connection
   - task: GoTool@0
     inputs:
-      version: "1.26.5"
+      version: "1.26.6"
 
   - script: |
       git config --global url.ssh://git@github.com/.insteadOf https://github.com/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/cluster-api-provider-azurestackhci
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.26.5
+  minimum_go_version=go1.26.6
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.


### PR DESCRIPTION
## What

Component Governance / vulnerability remediation.

Bumps the `go` directive **1.26.5 → 1.26.6** and **every** matching Go toolchain pin in the repo.

CAPH pins the Go version in five places. The first commit caught two of them; the second commit
catches the remaining three, which had silently left the **release** path on 1.26.5.

| File | Pin | Why it matters |
|---|---|---|
| `go.mod` | `go` directive | Language/toolchain floor |
| `.pipelines/build.yaml` | `GoTool@0` | PR/CI build |
| `azure-pipelines-release.yml` | `GoTool@0` | **Release build** — the shipped `caphcontroller` binary |
| `Makefile` | `GO_VERSION` fallback | Feeds `golang:$(GO_VERSION)` in the `release-binary` target |
| `hack/ensure-go.sh` | `minimum_go_version` | Dev-environment guard |

`azure-pipelines-release.yml` is the important one: without it the released binary would still have
been compiled with 1.26.5 and would have retained every stdlib CVE this PR sets out to clear.

## CVEs cleared

`govulncheck` on `master` (`acba42d`) reported 6 reachable Go **stdlib** vulnerabilities, all fixed in `go1.26.6`:

| ID | Package |
|---|---|
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` |
| [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091) | `html/template` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` |
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `net/http` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` |

## Verification

- `go build ./...` — OK
- `go mod verify` — all modules verified
- `govulncheck ./...` — **No vulnerabilities found** (0 remaining)
- `bash -n hack/ensure-go.sh` — syntax OK
- `make -n release-binary` — resolves `golang:1.26.6`
- `azure-pipelines-release.yml` — parses as valid YAML
- `grep -rn '1\.26\.5' .` (excluding `.git`, `vendor`, `*.sum`) — **no matches remain**

## Dependabot alerts — triaged, no action needed

The repo currently shows 2 open Dependabot alerts. Both were checked against the actual module graph and are **stale**:

| Alert | Status |
|---|---|
| `github.com/emicklei/go-restful` (critical, GHSA-r48q-9g5r-8q2h, fixed 2.16.0) | Stale — that module path is not in the graph. This repo uses `github.com/emicklei/go-restful/v3 v3.13.0`, a different module path already above the fix. |
| `github.com/elazarl/goproxy` (high, GHSA-4r8x-2p26-976p, fixed `v0.0.0-20230731152917-f99041a5c027`) | Stale — go.mod already has a `replace` pinning it to exactly that patched version. |

`go list -m` reports both as "not a known dependency" and `go mod why` as "main module does not need package", so no bump is warranted for either.

## Scope

Five one-line version-string changes across five files. No dependency changes, no code changes.
